### PR TITLE
Feat/initial configuration

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -1,31 +1,31 @@
 {
   "containerDefinitions": [
     {
-      "name": "tis-template",
-      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-template:latest",
+      "name": "tis-trainee-actions",
+      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-actions:latest",
       "secrets": [
         {
           "name": "SENTRY_DSN",
-          "valueFrom": "tis-template-sentry-dsn"
+          "valueFrom": "tis-trainee-actions-sentry-dsn"
         }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "awslogs-${environment}-tis-template",
+          "awslogs-group": "awslogs-${environment}-tis-trainee-actions",
           "awslogs-region": "eu-west-2",
-          "awslogs-stream-prefix": "awslogs-tis-template"
+          "awslogs-stream-prefix": "awslogs-tis-trainee-actions"
         }
       },
       "portMappings": [
         {
-          "containerPort": 8080
+          "containerPort": 8212
         }
       ],
       "environment": [
         {
           "name": "TITLE",
-          "value": "tis-template"
+          "value": "tis-trainee-actions"
         },
         {
           "name": "AWS_REGION",
@@ -38,7 +38,7 @@
       ]
     }
   ],
-  "family": "tis-template-${environment}",
+  "family": "tis-trainee-actions-${environment}",
   "requiresCompatibilities": [
     "FARGATE"
   ],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: weekly
     reviewers:
-      - Health-Education-England/external-admin-backend
-      - Health-Education-England/internal-admin-backend
       - Health-Education-England/trainee-backend
 
   - package-ecosystem: github-actions
@@ -14,9 +12,5 @@ updates:
     schedule:
       interval: weekly
     reviewers:
-      - Health-Education-England/external-admin-backend
-      - Health-Education-England/internal-admin-backend
       - Health-Education-England/trainee-backend
-      - Health-Education-England/external-admin-devops
-      - Health-Education-England/internal-admin-devops
       - Health-Education-England/trainee-devops

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,20 +6,10 @@ on:
       - main
 
 jobs:
-  # TODO: delete this build job and uncomment the ci-cd job once ready to deploy.
-  build:
-    uses: health-education-england/.github/.github/workflows/build-gradle.yml@main
+  ci-cd:
+    name: Build and deploy
+    uses: health-education-england/.github/.github/workflows/ci-cd-gradle.yml@main
     with:
-      # TODO: delete or set to true depending on codeartifict requirements
-      use-codeartifact: false
+      cluster-prefix: trainee
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
-
-#  ci-cd:
-#    name: Build and deploy
-#    uses: health-education-england/.github/.github/workflows/ci-cd-gradle.yml@main
-#    with:
-#      cluster-prefix: # TODO: add ECS cluster prefix
-#      use-codeartifact: false # TODO: delete or set to true depending on codeartifict requirements
-#    secrets:
-#      sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2022 Crown Copyright (Health Education England)
+Copyright 2024 Crown Copyright (Health Education England)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name                    | Description                                                        | Default   |
-|-------------------------|--------------------------------------------------------------------|-----------|
-| ENVIRONMENT             | The environment to log events against.                             | local     |
-| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional)             |           |
+| Name                    | Description                                            | Default   |
+|-------------------------|--------------------------------------------------------|-----------|
+| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                   |           |
+| ENVIRONMENT             | The environment to log events against.                 | local     |
+| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional) |           |
 
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -1,49 +1,50 @@
-# TIS Microservice Template
+# TIS Trainee Actions
 
 ## About
-This is a template to be used for TIS microservices with the following
-technology:
+This services manages actions that we require a trainee to perform, such as
 
- - Java 17
- - Spring Boot
- - Gradle
- - JUnit 5
+ - Reviewing held personal data
+ - Reviewing held training data
+ - Submitting required forms
 
-Boilerplate code is to be generated with:
- - Lombok
- - MapStruct
+## Developing
 
-Code quality checking and enforcement is done with the following tools:
- - EditorConfig
- - Checkstyle
- - JaCoCo
- - SonarQube
+### Running
 
-Error and exception logging is done using Sentry.
+```shell
+gradlew bootRun
+```
 
-## TODO
-To use this template, create a new repository from it and follow the TODOs in
-the code, with the following additional changes.
- - Update copyright year in [LICENSE](LICENSE).
- - Update copyright year in [TemplateApplication].
- - Update copyright year in [TemplateApplicationTest].
- - Update this README.
- - Sentry:
-    - Set up Sentry project.
-    - Provide `SENTRY_DSN` and `SENTRY_ENVIRONMENT` as environmental variables
-   during deployment.
- - Sonar:
-    - Add repository to SonarCloud.
-    - Add SonarCloud API key to repository secrets.
- - Update Dependabot configuration to remove unneeded teams.
- - Update the references to `tis-template` and port number in [task-definition].
+#### Environmental Variables
+
+| Name                    | Description                                                        | Default   |
+|-------------------------|--------------------------------------------------------------------|-----------|
+| ENVIRONMENT             | The environment to log events against.                             | local     |
+| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional)             |           |
+
+
+### Testing
+
+The Gradle `test` task can be used to run automated tests and produce coverage
+reports.
+```shell
+gradlew test
+```
+
+The Gradle `check` lifecycle task can be used to run automated tests and also
+verify formatting conforms to the code style guidelines.
+```shell
+gradlew check
+```
+
+### Building
+
+```shell
+gradlew bootBuildImage
+```
 
 ## Versioning
 This project uses [Semantic Versioning](semver.org).
 
 ## License
 This project is license under [The MIT License (MIT)](LICENSE).
-
-[task-definition]: .aws/task-definition-template.json
-[TemplateApplication]: src/main/java/uk/nhs/hee/tis/template/TemplateApplication.java
-[TemplateApplicationTest]: src/test/java/uk/nhs/hee/tis/template/TemplateApplicationTest.java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,7 @@ plugins {
   id("org.sonarqube") version "4.4.1.3373"
 }
 
-// TODO: Update group to end with "admin" or "trainee".
-group = "uk.nhs.tis"
+group = "uk.nhs.tis.trainee"
 version = "0.0.1"
 
 configurations {
@@ -61,8 +60,7 @@ sonarqube {
     property("sonar.host.url", "https://sonarcloud.io")
     property("sonar.login", System.getenv("SONAR_TOKEN"))
     property("sonar.organization", "health-education-england")
-    // TODO: Update sonar.projectKey to real value.
-    property("sonar.projectKey", "Health-Education-England_tis-microservice-template")
+    property("sonar.projectKey", "Health-Education-England_tis-trainee-actions")
 
     property("sonar.java.checkstyle.reportPaths",
       "build/reports/checkstyle/main.xml,build/reports/checkstyle/test.xml")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.0.1"
+version = "0.0.2"
 
 configurations {
   compileOnly {
@@ -27,6 +27,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.boot:spring-boot-starter-web")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+  // AWS
+  implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.15.0")
 
   // Lombok
   compileOnly("org.projectlombok:lombok")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,1 @@
-// TODO: Update project name.
-rootProject.name = "tis-microservice-template"
+rootProject.name = "tis-trainee-actions"

--- a/src/main/java/uk/nhs/tis/trainee/actions/TisTraineeActionsApplication.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/TisTraineeActionsApplication.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,16 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.template;
+package uk.nhs.tis.trainee.actions;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-//TODO: Update package and class name.
-public class TemplateApplication {
+public class TisTraineeActionsApplication {
 
   public static void main(String[] args) {
-    SpringApplication.run(TemplateApplication.class);
+    SpringApplication.run(TisTraineeActionsApplication.class);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/config/ApplicationConfiguration.java
@@ -19,18 +19,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions;
+package uk.nhs.tis.trainee.actions.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 /**
- * An application for the management of trainee actions.
+ * General application configuration beans which do not warrant their own configuration class.
  */
-@SpringBootApplication
-public class TisTraineeActionsApplication {
+@Configuration
+public class ApplicationConfiguration {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeActionsApplication.class);
+  @Bean
+  RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder.build();
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/config/AwsXrayConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/config/AwsXrayConfiguration.java
@@ -19,18 +19,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions;
+package uk.nhs.tis.trainee.actions.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
+import jakarta.servlet.Filter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
- * An application for the management of trainee actions.
+ * Configuration for AWS X-Ray, conditional on daemon configuration being present.
  */
-@SpringBootApplication
-public class TisTraineeActionsApplication {
+@Configuration
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
+    + ".isEmpty('${com.amazonaws.xray.emitters.daemon-address}')")
+public class AwsXrayConfiguration {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeActionsApplication.class);
+  @Bean
+  public Filter tracingFilter(@Value("${application.environment}") String environment) {
+    return new AWSXRayServletFilter("tis-trainee-actions-" + environment);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/config/AwsXrayInterceptor.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/config/AwsXrayInterceptor.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.config;
+
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.spring.aop.BaseAbstractXRayInterceptor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Optional;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata;
+
+/**
+ * Configuration for AWS X-Ray interceptor, conditional on daemon configuration being present.
+ */
+@Aspect
+@Component
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
+    + ".isEmpty('${com.amazonaws.xray.emitters.daemon-address}')")
+public class AwsXrayInterceptor extends BaseAbstractXRayInterceptor {
+
+  private final EcsMetadata ecsMetadata;
+  private final ObjectMapper mapper;
+
+  AwsXrayInterceptor(Optional<EcsMetadata> ecsMetadata, ObjectMapper mapper) {
+    this.ecsMetadata = ecsMetadata.orElse(null);
+    this.mapper = mapper;
+  }
+
+  @Override
+  protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint pjp,
+      Subsegment subsegment) {
+    Map<String, Map<String, Object>> metadata = super.generateMetadata(pjp, subsegment);
+
+    Map<String, Object> taskMetadataMap = mapper.convertValue(ecsMetadata, new TypeReference<>() {
+    });
+    metadata.put("EcsMetadata", taskMetadataMap);
+
+    return metadata;
+  }
+
+  @Override
+  @Pointcut("@within(com.amazonaws.xray.spring.aop.XRayEnabled))")
+  public void xrayEnabledClasses() {
+
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/config/EcsMetadataConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/config/EcsMetadataConfiguration.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.TaskMetadata;
+
+/**
+ * Configuration for retrieval of ECS metadata.
+ */
+@Configuration
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
+    + ".isEmpty('${ecs.container.metadata.uri.v4:}')")
+public class EcsMetadataConfiguration {
+
+  /**
+   * Generate ECS metadata based on the ECS metadata endpoint.
+   *
+   * @param restTemplate     The rest template to call the endpoint with.
+   * @param metadataEndpoint The endpoint to call to get ECS metadata.
+   * @return The parsed ECS metadata.
+   */
+  @Bean
+  public EcsMetadata ecsMetadata(RestTemplate restTemplate,
+      @Value("${ecs.container.metadata.uri.v4}") String metadataEndpoint) {
+    ContainerMetadata containerMetadata = restTemplate.getForObject(metadataEndpoint,
+        ContainerMetadata.class);
+    TaskMetadata taskMetadata = restTemplate.getForObject(metadataEndpoint + "/task",
+        TaskMetadata.class);
+
+    return new EcsMetadata(taskMetadata, containerMetadata);
+  }
+
+  /**
+   * A representation of ECS metadata.
+   *
+   * @param taskMetadata      The ECS task metadata.
+   * @param containerMetadata The ECS container metadata.
+   */
+  public record EcsMetadata(
+      @JsonProperty("TaskMetadata")
+      TaskMetadata taskMetadata,
+
+      @JsonProperty("ContainerMetadata")
+      ContainerMetadata containerMetadata) {
+
+    /**
+     * A representation of ECS task metadata.
+     *
+     * @param cluster  The ECS cluster.
+     * @param taskArn  The running task's ARN.
+     * @param family   The task definition family.
+     * @param revision The task definition revision.
+     */
+    record TaskMetadata(
+        @JsonProperty("Cluster")
+        String cluster,
+
+        @JsonProperty("TaskARN")
+        String taskArn,
+
+        @JsonProperty("Family")
+        String family,
+
+        @JsonProperty("Revision")
+        String revision) {
+
+    }
+
+    /**
+     * A representation of ECS container metadata.
+     *
+     * @param containerArn The ECS container ARN.
+     * @param logOptions   The container's log options.
+     */
+    record ContainerMetadata(
+
+        @JsonProperty("ContainerARN")
+        String containerArn,
+
+        @JsonProperty("LogOptions")
+        LogOptions logOptions) {
+
+      /**
+       * A representation of ECS container log options.
+       *
+       * @param logGroup  The container's log group.
+       * @param region    The container's log region.
+       * @param logStream The container's current log stream.
+       */
+      record LogOptions(
+          @JsonProperty("awslogs-group")
+          String logGroup,
+
+          @JsonProperty("awslogs-region")
+          String region,
+
+          @JsonProperty("awslogs-stream")
+          String logStream) {
+
+      }
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/config/SentryConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/config/SentryConfiguration.java
@@ -19,18 +19,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions;
+package uk.nhs.tis.trainee.actions.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import io.sentry.Sentry;
+import jakarta.annotation.PostConstruct;
+import java.util.Optional;
+import org.springframework.context.annotation.Configuration;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata;
 
 /**
- * An application for the management of trainee actions.
+ * Additional configuration for Sentry.
  */
-@SpringBootApplication
-public class TisTraineeActionsApplication {
+@Configuration
+public class SentryConfiguration {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeActionsApplication.class);
+  private final Optional<EcsMetadata> ecsMetadata;
+
+  SentryConfiguration(Optional<EcsMetadata> ecsMetadata) {
+    this.ecsMetadata = ecsMetadata;
+  }
+
+  /**
+   * Configure the Sentry scope with additional ECS metadata.
+   */
+  @PostConstruct
+  void configureScope() {
+    ecsMetadata.ifPresent(metadata ->
+        Sentry.configureScope(scope -> scope.setContexts("EcsMetadata", metadata))
+    );
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 application:
   environment: ${ENVIRONMENT:local}
 
+com:
+  amazonaws:
+    xray:
+      emitters:
+        daemon-address: ${AWS_XRAY_DAEMON_ADDRESS:}
+
 server:
   port: 8212
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,11 @@
+application:
+  environment: ${ENVIRONMENT:local}
+
 server:
-  # TODO: Update server port and context path to a unique value.
-  port: 8080
+  port: 8212
   servlet:
-    context-path: /template
+    context-path: /actions
 
 sentry:
   dsn: ${SENTRY_DSN:}
-  environment: ${SENTRY_ENVIRONMENT:}
+  environment: ${application.environment}

--- a/src/test/java/uk/nhs/tis/trainee/actions/TisTraineeActionsApplicationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/TisTraineeActionsApplicationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,14 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.template;
+package uk.nhs.tis.trainee.actions;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-//TODO: Update package and class name.
-class TemplateApplicationTest {
+class TisTraineeActionsApplicationTest {
 
   @Test
   void contextLoads() {

--- a/src/test/java/uk/nhs/tis/trainee/actions/config/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/config/ApplicationConfigurationTest.java
@@ -19,18 +19,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions;
+package uk.nhs.tis.trainee.actions.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-/**
- * An application for the management of trainee actions.
- */
-@SpringBootApplication
-public class TisTraineeActionsApplication {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeActionsApplication.class);
+class ApplicationConfigurationTest {
+
+  private ApplicationConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new ApplicationConfiguration();
+  }
+
+  @Test
+  void restTemplate() {
+    RestTemplateBuilder restTemplateBuilder = new RestTemplateBuilder();
+
+    RestTemplate restTemplate = configuration.restTemplate(restTemplateBuilder);
+
+    assertThat("Unexpected rest template.", restTemplate, notNullValue());
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/actions/config/AwsXrayConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/config/AwsXrayConfigurationTest.java
@@ -19,18 +19,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions;
+package uk.nhs.tis.trainee.actions.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-/**
- * An application for the management of trainee actions.
- */
-@SpringBootApplication
-public class TisTraineeActionsApplication {
+import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeActionsApplication.class);
+class AwsXrayConfigurationTest {
+
+  private AwsXrayConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new AwsXrayConfiguration();
+  }
+
+  @Test
+  void shouldCreateInstanceOfAwsXrayServletFilter() {
+    Filter filter = configuration.tracingFilter("testEnvironment");
+
+    assertThat("Unexpected filter type.", filter, instanceOf(AWSXRayServletFilter.class));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/actions/config/AwsXrayInterceptorTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/config/AwsXrayInterceptorTest.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.xray.entities.Subsegment;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Optional;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata.LogOptions;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.TaskMetadata;
+
+class AwsXrayInterceptorTest {
+
+  private ObjectMapper objectMapper;
+  private ProceedingJoinPoint pjp;
+  private Subsegment subsegment;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    subsegment = mock(Subsegment.class);
+
+    pjp = mock(ProceedingJoinPoint.class);
+    when(pjp.getTarget()).thenReturn(Object.class);
+  }
+
+  @Test
+  void shouldGenerateNullEcsMetadataWhenNotAvailable() {
+    AwsXrayInterceptor interceptor = new AwsXrayInterceptor(Optional.empty(), objectMapper);
+
+    Map<String, Map<String, Object>> metadata = interceptor.generateMetadata(pjp, subsegment);
+
+    assertThat("Unexpected X-Ray metadata.", metadata, notNullValue());
+
+    Map<String, Object> ecsMetadataMap = metadata.get("EcsMetadata");
+    assertThat("Unexpected ECS metadata.", ecsMetadataMap, nullValue());
+  }
+
+  @Test
+  void shouldGenerateEcsMetadataWhenAvailable() {
+    EcsMetadata ecsMetadata = new EcsMetadata(
+        new TaskMetadata("cluster", "taskArn", "family", "revision"),
+        new ContainerMetadata("containerArn", new LogOptions("logGroup", "region", "logStream")));
+    AwsXrayInterceptor interceptor = new AwsXrayInterceptor(Optional.of(ecsMetadata), objectMapper);
+
+    Map<String, Map<String, Object>> metadata = interceptor.generateMetadata(pjp, subsegment);
+
+    assertThat("Unexpected X-Ray metadata.", metadata, notNullValue());
+
+    Map<String, Object> ecsMetadataMap = metadata.get("EcsMetadata");
+    assertThat("Unexpected ECS metadata.", ecsMetadataMap, notNullValue());
+
+    Map<String, Object> taskMetadataMap = (Map<String, Object>) ecsMetadataMap.get("TaskMetadata");
+    assertThat("Unexpected task metadata.", taskMetadataMap, notNullValue());
+    assertThat("Unexpected cluster.", taskMetadataMap.get("Cluster"), is("cluster"));
+    assertThat("Unexpected task ARN.", taskMetadataMap.get("TaskARN"), is("taskArn"));
+    assertThat("Unexpected family.", taskMetadataMap.get("Family"), is("family"));
+
+    Map<String, Object> containerMetadataMap = (Map<String, Object>) ecsMetadataMap.get(
+        "ContainerMetadata");
+    assertThat("Unexpected container metadata.", containerMetadataMap, notNullValue());
+    assertThat("Unexpected container ARN.", containerMetadataMap.get("ContainerARN"),
+        is("containerArn"));
+
+    Map<String, Object> logOptionsMap = (Map<String, Object>) containerMetadataMap.get(
+        "LogOptions");
+    assertThat("Unexpected log options metadata.", logOptionsMap, notNullValue());
+    assertThat("Unexpected log group.", logOptionsMap.get("awslogs-group"), is("logGroup"));
+    assertThat("Unexpected log region.", logOptionsMap.get("awslogs-region"), is("region"));
+    assertThat("Unexpected log stream.", logOptionsMap.get("awslogs-stream"), is("logStream"));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/config/EcsMetadataConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/config/EcsMetadataConfigurationTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.ContainerMetadata.LogOptions;
+import uk.nhs.tis.trainee.actions.config.EcsMetadataConfiguration.EcsMetadata.TaskMetadata;
+
+class EcsMetadataConfigurationTest {
+
+  private static final String ECS_METADATA_ENDPOINT = "https://ecs.metadata/endpoint";
+
+  private EcsMetadataConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new EcsMetadataConfiguration();
+  }
+
+  @Test
+  void shouldReturnEcsMetadataWhenEndpointFound() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(ECS_METADATA_ENDPOINT, ContainerMetadata.class)).thenReturn(
+        new ContainerMetadata("containerArn", new LogOptions("logGroup", "region", "logStream")));
+    when(restTemplate.getForObject(ECS_METADATA_ENDPOINT + "/task", TaskMetadata.class)).thenReturn(
+        new TaskMetadata("cluster", "taskArn", "family", "revision"));
+
+    EcsMetadata ecsMetadata = configuration.ecsMetadata(restTemplate, ECS_METADATA_ENDPOINT);
+
+    assertThat("Unexpected ECS metadata.", ecsMetadata, notNullValue());
+
+    TaskMetadata taskMetadata = ecsMetadata.taskMetadata();
+    assertThat("Unexpected task metadata.", taskMetadata, notNullValue());
+    assertThat("Unexpected cluster.", taskMetadata.cluster(), is("cluster"));
+    assertThat("Unexpected task ARN.", taskMetadata.taskArn(), is("taskArn"));
+    assertThat("Unexpected family.", taskMetadata.family(), is("family"));
+
+    ContainerMetadata containerMetadata = ecsMetadata.containerMetadata();
+    assertThat("Unexpected container metadata.", containerMetadata, notNullValue());
+    assertThat("Unexpected container ARN.", containerMetadata.containerArn(), is("containerArn"));
+
+    LogOptions logOptions = containerMetadata.logOptions();
+    assertThat("Unexpected task metadata.", logOptions, notNullValue());
+    assertThat("Unexpected log group.", logOptions.logGroup(), is("logGroup"));
+    assertThat("Unexpected log region.", logOptions.region(), is("region"));
+    assertThat("Unexpected log stream.", logOptions.logStream(), is("logStream"));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenMetadataEndpointNotFound() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(any(String.class), any())).thenThrow(RestClientException.class);
+
+    assertThrows(RestClientException.class,
+        () -> configuration.ecsMetadata(restTemplate, ECS_METADATA_ENDPOINT));
+  }
+}


### PR DESCRIPTION
refactor: initialise project from template
Follow the template TODOs to create the actions service.

---

feat: additional monitoring configuration
Add XRay tracing configuration.

ECS metadata should be retrieved when appropriate and added to both XRay
traces and Sentry error logs.

TIS21-5582
TIS21-5585