### PR TITLE
Feat/store pm review on pm create

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -5,6 +5,10 @@
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-actions:latest",
       "secrets": [
         {
+          "name": "PROGRAMME_MEMBERSHIP_SYNCED_QUEUE",
+          "valueFrom": "/tis/trainee/actions/${environment}/queue-url/programme-membership/synced"
+        },
+        {
           "name": "SENTRY_DSN",
           "valueFrom": "tis-trainee-actions-sentry-dsn"
         }

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -5,8 +5,28 @@
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-actions:latest",
       "secrets": [
         {
+          "name": "AWS_XRAY_DAEMON_ADDRESS",
+          "valueFrom": "/tis/monitoring/xray/daemon-host"
+        },
+        {
           "name": "PROGRAMME_MEMBERSHIP_SYNCED_QUEUE",
           "valueFrom": "/tis/trainee/actions/${environment}/queue-url/programme-membership/synced"
+        },
+        {
+          "name": "MONGO_HOST",
+          "valueFrom": "/tis/trainee/${environment}/db/host"
+        },
+        {
+          "name": "MONGO_PORT",
+          "valueFrom": "/tis/trainee/${environment}/db/port"
+        },
+        {
+          "name": "MONGO_USER",
+          "valueFrom": "/tis/trainee/${environment}/db/username"
+        },
+        {
+          "name": "MONGO_PASSWORD",
+          "valueFrom": "/tis/trainee/${environment}/db/password"
         },
         {
           "name": "SENTRY_DSN",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,12 @@ repositories {
   mavenCentral()
 }
 
+dependencyManagement {
+  imports {
+    mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0")
+  }
+}
+
 dependencies {
   // Spring Boot starters
   implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -30,6 +36,7 @@ dependencies {
 
   // AWS
   implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.15.0")
+  implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
 
   // Lombok
   compileOnly("org.projectlombok:lombok")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.0.2"
+version = "0.1.0"
 
 configurations {
   compileOnly {
@@ -31,6 +31,7 @@ dependencyManagement {
 dependencies {
   // Spring Boot starters
   implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
   implementation("org.springframework.boot:spring-boot-starter-web")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDto.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDate;
+
+/**
+ * A representation of a programme membership.
+ *
+ * @param id        The programme membership ID.
+ * @param traineeId The trainee ID associated with the membership.
+ * @param startDate The programme start date.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProgrammeMembershipDto(@JsonAlias("tisId") String id,
+                                     @JsonAlias("personId") String traineeId, LocalDate startDate) {
+
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/Operation.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/Operation.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+/**
+ * A representation of the possible event operations.
+ */
+public enum Operation {
+
+  CREATE, DELETE, LOAD, UPDATE
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipEvent.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+
+/**
+ * A programme membership event.
+ */
+@Getter
+public class ProgrammeMembershipEvent extends RecordEvent {
+
+  private ProgrammeMembershipDto programmeMembership;
+
+  @Override
+  protected void unpackData(JsonNode data) {
+    programmeMembership = getObjectMapper().convertValue(data, ProgrammeMembershipDto.class);
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListener.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.service.ActionService;
+
+/**
+ * A listener for programme membership events.
+ */
+@Slf4j
+@Component
+public class ProgrammeMembershipListener {
+
+  private final ActionService actionService;
+
+  public ProgrammeMembershipListener(ActionService actionService) {
+    this.actionService = actionService;
+  }
+
+  /**
+   * Handle a programme membership sync event.
+   *
+   * @param event The event to handle.
+   */
+  @SqsListener("${application.queues.programme-membership-synced}")
+  public void handleProgrammeMembershipSync(ProgrammeMembershipEvent event) {
+    log.debug("Programme membership sync event received: {}", event);
+    Operation operation = event.getOperation();
+    ProgrammeMembershipDto dto = event.getProgrammeMembership();
+
+    if (operation != null && dto != null) {
+      actionService.updateActions(operation, event.getProgrammeMembership());
+    } else {
+      throw new IllegalArgumentException("Skipping event handling due to incomplete event data.");
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/RecordEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/RecordEvent.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+
+/**
+ * An abstract representation of a record event.
+ */
+@Getter
+public abstract class RecordEvent {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
+
+  private Operation operation;
+
+  /**
+   * Unpack the record node of the event JSON.
+   * @param recordNode The node to unpack.
+   */
+  @JsonProperty("record")
+  private void unpackRecord(JsonNode recordNode) {
+    operation = getObjectMapper().convertValue(recordNode.get("operation"), Operation.class);
+    unpackData(recordNode.get("data"));
+  }
+
+  /**
+   * Unpack the data node of the event JSON.
+   * @param dataNode The data node to unpack.
+   */
+  protected abstract void unpackData(JsonNode dataNode);
+
+  /**
+   * Get a configured object mapper to use for object conversion.
+   * @return The configured object mapper.
+   */
+  protected ObjectMapper getObjectMapper() {
+    return OBJECT_MAPPER;
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.model.Action;
+import uk.nhs.tis.trainee.actions.model.Action.TisReferenceInfo;
+import uk.nhs.tis.trainee.actions.model.ActionType;
+
+/**
+ * A mapper to convert to and between Action data types.
+ */
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface ActionMapper {
+
+  /**
+   * Create an action using Programme Membership data.
+   *
+   * @param dto  The Programme Membership to retrieve data from.
+   * @param type The type of action to be created.
+   * @return The created action.
+   */
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "type", source = "type")
+  @Mapping(target = "traineeId", source = "dto.traineeId")
+  @Mapping(target = "tisReferenceInfo", source = "dto")
+  @Mapping(target = "due", source = "dto.startDate")
+  @Mapping(target = "completed", ignore = true)
+  Action toAction(ProgrammeMembershipDto dto, ActionType type);
+
+  /**
+   * Map a Programme Membership to a TIS reference info object.
+   *
+   * @param dto The Programme Membership to map.
+   * @return A reference to the TIS core object.
+   */
+  @Mapping(target = "id", source = "dto.id")
+  @Mapping(target = "type", constant = "PROGRAMME_MEMBERSHIP")
+  TisReferenceInfo map(ProgrammeMembershipDto dto);
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/Action.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/Action.java
@@ -19,47 +19,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.event;
+package uk.nhs.tis.trainee.actions.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
+import java.time.Instant;
+import java.time.LocalDate;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
- * An abstract representation of a record event.
+ * A representation of a pending or completed trainee action.
+ *
+ * @param id               The ID of the action.
+ * @param type             The type of action.
+ * @param traineeId        The ID of the trainee who the action is for.
+ * @param tisReferenceInfo The TIS core object associated with the action.
+ * @param due              When the action is due.
+ * @param completed        When the action was completed, null if not completed.
  */
-@Getter
-public abstract class RecordEvent {
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
-
-  private Operation operation;
-
-  /**
-   * Unpack the record node of the event JSON.
-   *
-   * @param recordNode The node to unpack.
-   */
-  @JsonProperty("record")
-  private void unpackRecord(JsonNode recordNode) {
-    operation = getObjectMapper().convertValue(recordNode.get("operation"), Operation.class);
-    unpackData(recordNode.get("data"));
-  }
+@Document(collection = "Action")
+public record Action(
+    @Id
+    ObjectId id,
+    ActionType type,
+    String traineeId,
+    TisReferenceInfo tisReferenceInfo,
+    LocalDate due,
+    Instant completed) {
 
   /**
-   * Unpack the data node of the event JSON.
+   * A representation of the TIS record that prompted the action.
    *
-   * @param dataNode The data node to unpack.
+   * @param id   The TIS ID of the entity that prompted the action.
+   * @param type The TIS reference type for the entity that prompted the action.
    */
-  protected abstract void unpackData(JsonNode dataNode);
+  public record TisReferenceInfo(String id, TisReferenceType type) {
 
-  /**
-   * Get a configured object mapper to use for object conversion.
-   *
-   * @return The configured object mapper.
-   */
-  protected ObjectMapper getObjectMapper() {
-    return OBJECT_MAPPER;
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
@@ -19,47 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.event;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
+package uk.nhs.tis.trainee.actions.model;
 
 /**
- * An abstract representation of a record event.
+ * The type category of the action to be performed.
  */
-@Getter
-public abstract class RecordEvent {
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
-
-  private Operation operation;
-
-  /**
-   * Unpack the record node of the event JSON.
-   *
-   * @param recordNode The node to unpack.
-   */
-  @JsonProperty("record")
-  private void unpackRecord(JsonNode recordNode) {
-    operation = getObjectMapper().convertValue(recordNode.get("operation"), Operation.class);
-    unpackData(recordNode.get("data"));
-  }
-
-  /**
-   * Unpack the data node of the event JSON.
-   *
-   * @param dataNode The data node to unpack.
-   */
-  protected abstract void unpackData(JsonNode dataNode);
-
-  /**
-   * Get a configured object mapper to use for object conversion.
-   *
-   * @return The configured object mapper.
-   */
-  protected ObjectMapper getObjectMapper() {
-    return OBJECT_MAPPER;
-  }
+public enum ActionType {
+  REVIEW_DATA
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/TisReferenceType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/TisReferenceType.java
@@ -19,47 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.event;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
+package uk.nhs.tis.trainee.actions.model;
 
 /**
- * An abstract representation of a record event.
+ * An enumeration of possible TIS reference (core entity) types.
  */
-@Getter
-public abstract class RecordEvent {
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
-
-  private Operation operation;
-
-  /**
-   * Unpack the record node of the event JSON.
-   *
-   * @param recordNode The node to unpack.
-   */
-  @JsonProperty("record")
-  private void unpackRecord(JsonNode recordNode) {
-    operation = getObjectMapper().convertValue(recordNode.get("operation"), Operation.class);
-    unpackData(recordNode.get("data"));
-  }
-
-  /**
-   * Unpack the data node of the event JSON.
-   *
-   * @param dataNode The data node to unpack.
-   */
-  protected abstract void unpackData(JsonNode dataNode);
-
-  /**
-   * Get a configured object mapper to use for object conversion.
-   *
-   * @return The configured object mapper.
-   */
-  protected ObjectMapper getObjectMapper() {
-    return OBJECT_MAPPER;
-  }
+public enum TisReferenceType {
+  PROGRAMME_MEMBERSHIP
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
@@ -19,47 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.event;
+package uk.nhs.tis.trainee.actions.repository;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.tis.trainee.actions.model.Action;
 
 /**
- * An abstract representation of a record event.
+ * A repository of trainee actions.
  */
-@Getter
-public abstract class RecordEvent {
+@Repository
+public interface ActionRepository extends MongoRepository<Action, ObjectId> {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
-
-  private Operation operation;
-
-  /**
-   * Unpack the record node of the event JSON.
-   *
-   * @param recordNode The node to unpack.
-   */
-  @JsonProperty("record")
-  private void unpackRecord(JsonNode recordNode) {
-    operation = getObjectMapper().convertValue(recordNode.get("operation"), Operation.class);
-    unpackData(recordNode.get("data"));
-  }
-
-  /**
-   * Unpack the data node of the event JSON.
-   *
-   * @param dataNode The data node to unpack.
-   */
-  protected abstract void unpackData(JsonNode dataNode);
-
-  /**
-   * Get a configured object mapper to use for object conversion.
-   *
-   * @return The configured object mapper.
-   */
-  protected ObjectMapper getObjectMapper() {
-    return OBJECT_MAPPER;
-  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -21,18 +21,56 @@
 
 package uk.nhs.tis.trainee.actions.service;
 
+import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
 import uk.nhs.tis.trainee.actions.event.Operation;
+import uk.nhs.tis.trainee.actions.mapper.ActionMapper;
 import uk.nhs.tis.trainee.actions.model.Action;
+import uk.nhs.tis.trainee.actions.repository.ActionRepository;
 
+/**
+ * A service provided Action functionality.
+ */
 @Slf4j
 @Service
 public class ActionService {
 
-  public Action updateActions(Operation operation, ProgrammeMembershipDto programmeMembership) {
-    log.info("Action service called for '{}' operation.");
-    return null;
+  private final ActionRepository repository;
+  private final ActionMapper mapper;
+
+  public ActionService(ActionRepository repository, ActionMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Updates the actions associated with the given Operation and Programme Membership data.
+   *
+   * @param operation The operation that triggered the update.
+   * @param dto       The Programme Membership data associated with the operation.
+   * @return A list of updated actions, empty if no actions required.
+   */
+  public List<Action> updateActions(Operation operation,
+      ProgrammeMembershipDto dto) {
+    List<Action> actions = new ArrayList<>();
+
+    if (Objects.equals(operation, Operation.CREATE)) {
+      Action action = mapper.toAction(dto, REVIEW_DATA);
+      actions.add(action);
+    }
+
+    if (actions.isEmpty()) {
+      log.info("No new actions required for Programme Membership {}", dto.id());
+      return List.of();
+    }
+
+    log.info("Adding {} new action(s) for Programme Membership {}.", actions.size(), dto.id());
+    return repository.insert(actions);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.event.Operation;
+import uk.nhs.tis.trainee.actions.model.Action;
+
+@Slf4j
+@Service
+public class ActionService {
+
+  public Action updateActions(Operation operation, ProgrammeMembershipDto programmeMembership) {
+    log.info("Action service called for '{}' operation.");
+    return null;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 application:
   environment: ${ENVIRONMENT:local}
+  queues:
+    programme-membership-synced: ${PROGRAMME_MEMBERSHIP_SYNCED_QUEUE}
 
 com:
   amazonaws:
@@ -15,3 +17,11 @@ server:
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${application.environment}
+
+spring:
+  cloud:
+    aws:
+      endpoint: ${AWS_ENDPOINT:}
+  data:
+    mongodb:
+      uri: mongodb://${MONGO_USER:admin}:${MONGO_PASSWORD:pwd}@${MONGO_HOST:localhost}:${MONGO_PORT:27017}/${MONGO_DB:actions}?authSource=admin

--- a/src/test/java/uk/nhs/tis/trainee/actions/TisTraineeActionsApplicationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/TisTraineeActionsApplicationTest.java
@@ -23,9 +23,16 @@ package uk.nhs.tis.trainee.actions;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import uk.nhs.tis.trainee.actions.config.MongoConfiguration;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class TisTraineeActionsApplicationTest {
+
+  @MockBean
+  private MongoConfiguration mongoConfiguration;
 
   @Test
   void contextLoads() {

--- a/src/test/java/uk/nhs/tis/trainee/actions/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/config/MongoConfigurationTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.config;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import uk.nhs.tis.trainee.actions.model.Action;
+
+class MongoConfigurationTest {
+
+  private MongoConfiguration configuration;
+
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    configuration = new MongoConfiguration(template);
+  }
+
+  @Test
+  void shouldInitIndexesForActionCollection() {
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(Action.class)).thenReturn(indexOperations);
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+
+    List<Index> indexes = indexCaptor.getAllValues();
+    assertThat("Unexpected number of indexes.", indexes.size(), is(2));
+
+    List<String> indexKeys = indexes.stream()
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected number of index keys.", indexKeys.size(), is(3));
+  }
+
+  @Test
+  void shouldInitTraineeIndexForActionCollection() {
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(Action.class)).thenReturn(indexOperations);
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+
+    List<Index> indexes = indexCaptor.getAllValues();
+    Set<String> indexKeys = indexes.stream()
+        .filter(i -> i.getIndexOptions().get("name").equals("traineeIndex"))
+        .map(i -> i.getIndexKeys().keySet())
+        .findAny()
+        .orElseThrow();
+    assertThat("Unexpected number of index keys.", indexKeys.size(), is(1));
+    assertThat("Unexpected index keys.", indexKeys, hasItems("traineeId"));
+  }
+
+  @Test
+  void shouldInitUniqueActionIndexForActionCollection() {
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(Action.class)).thenReturn(indexOperations);
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+
+    List<Index> indexes = indexCaptor.getAllValues();
+    Set<String> indexKeys = indexes.stream()
+        .filter(i -> i.getIndexOptions().get("name").equals("uniqueActionPerReference"))
+        .map(i -> i.getIndexKeys().keySet())
+        .findAny()
+        .orElseThrow();
+    assertThat("Unexpected number of index keys.", indexKeys.size(), is(2));
+    assertThat("Unexpected index keys.", indexKeys, hasItems("type", "tisReference"));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.service.ActionService;
+
+class ProgrammeMembershipListenerTest {
+
+  private static final String PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final LocalDate START_DATE = LocalDate.now();
+
+  private ProgrammeMembershipListener listener;
+  private ActionService service;
+
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(ActionService.class);
+    listener = new ProgrammeMembershipListener(service);
+    mapper = new ObjectMapper().findAndRegisterModules();
+  }
+
+  @Test
+  void shouldThrowExceptionWhenSyncEventOperationNull() throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "personId": "%s",
+              "startDate": "%s"
+            }
+          }
+        }""".formatted(PROGRAMME_MEMBERSHIP_ID, TRAINEE_ID, START_DATE);
+    ProgrammeMembershipEvent event = mapper.readValue(eventJson, ProgrammeMembershipEvent.class);
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handleProgrammeMembershipSync(event));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Operation.class)
+  void shouldThrowExceptionWhenSyncEventDataNull(Operation operation)
+      throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "operation": "%s"
+          }
+        }""".formatted(operation);
+    ProgrammeMembershipEvent event = mapper.readValue(eventJson, ProgrammeMembershipEvent.class);
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handleProgrammeMembershipSync(event));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Operation.class)
+  void shouldUpdateActionsWhenSyncEventValid(Operation operation) throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "personId": "%s",
+              "startDate": "%s"
+            },
+            "operation": "%s"
+          }
+        }""".formatted(PROGRAMME_MEMBERSHIP_ID, TRAINEE_ID, START_DATE, operation);
+    ProgrammeMembershipEvent event = mapper.readValue(eventJson, ProgrammeMembershipEvent.class);
+
+    listener.handleProgrammeMembershipSync(event);
+
+    ArgumentCaptor<ProgrammeMembershipDto> dtoCaptor = ArgumentCaptor.forClass(
+        ProgrammeMembershipDto.class);
+    verify(service).updateActions(eq(operation), dtoCaptor.capture());
+
+    ProgrammeMembershipDto dto = dtoCaptor.getValue();
+    assertThat("Unexpected ID", dto.id(), is(PROGRAMME_MEMBERSHIP_ID));
+    assertThat("Unexpected trainee ID", dto.traineeId(), is(TRAINEE_ID));
+    assertThat("Unexpected start date", dto.startDate(), is(START_DATE));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
+import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.event.Operation;
+import uk.nhs.tis.trainee.actions.mapper.ActionMapperImpl;
+import uk.nhs.tis.trainee.actions.model.Action;
+import uk.nhs.tis.trainee.actions.model.Action.TisReferenceInfo;
+import uk.nhs.tis.trainee.actions.repository.ActionRepository;
+
+class ActionServiceTest {
+
+  private static final String TIS_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final LocalDate TOMORROW = LocalDate.now().plusDays(1);
+
+  private ActionService service;
+  private ActionRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(ActionRepository.class);
+    service = new ActionService(repository, new ActionMapperImpl());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = Operation.class, names = {"CREATE"}, mode = EXCLUDE)
+  void shouldNotInsertActionWhenProgrammeMembershipOperationNotSupported(Operation operation) {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, TOMORROW);
+
+    service.updateActions(operation, dto);
+
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldInsertDataReviewActionOnProgrammeMembershipCreate() {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, TOMORROW);
+
+    when(repository.insert(anyIterable())).thenAnswer(inv -> inv.getArgument(0));
+
+    List<Action> actions = service.updateActions(Operation.CREATE, dto);
+
+    assertThat("Unexpected action count.", actions.size(), is(1));
+
+    Action action = actions.get(0);
+    assertThat("Unexpected action id.", action.id(), nullValue());
+    assertThat("Unexpected action type.", action.type(), is(REVIEW_DATA));
+    assertThat("Unexpected trainee id.", action.traineeId(), is(TRAINEE_ID));
+    assertThat("Unexpected due date.", action.due(), is(TOMORROW));
+    assertThat("Unexpected completed date.", action.completed(), nullValue());
+
+    TisReferenceInfo tisReference = action.tisReferenceInfo();
+    assertThat("Unexpected TIS id.", tisReference.id(), is(TIS_ID));
+    assertThat("Unexpected TIS type.", tisReference.type(), is(PROGRAMME_MEMBERSHIP));
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,7 @@
+spring:
+  cloud:
+    aws:
+      region:
+        static: aws-global
+      sqs:
+        enabled: false


### PR DESCRIPTION
feat: implement event listener
Create an event listener to listen for Programme Membership sync events
and call the action service when the event is valid.

---

feat: store PM review action on PM create
Configure MongoDB and update the ActionService to insert an Action to
the database, the action should be to review the PM data when created.

---

TIS21-5582
TIS21-5585

