### PR TITLE
test: create integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,18 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name                    | Description                                            | Default   |
-|-------------------------|--------------------------------------------------------|-----------|
-| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                   |           |
-| ENVIRONMENT             | The environment to log events against.                 | local     |
-| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional) |           |
+| Name                              | Description                                             | Default   |
+|-----------------------------------|---------------------------------------------------------|-----------|
+| AWS_ENDPOINT                      | The AWS endpoint to use, used for local dev. (Optional) |           |
+| AWS_XRAY_DAEMON_ADDRESS           | The AWS XRay daemon host. (Optional)                    |           |
+| ENVIRONMENT                       | The environment to log events against.                  | local     |
+| MONGO_DB                          | The name of the MongoDB database.                       | actions   |
+| MONGO_HOST                        | The MongoDB database server host.                       | localhost |
+| MONGO_PASSWORD                    | The login password for the MongoDB database.            | pwd       |
+| MONGO_PORT                        | The MongoDB database server port.                       | 27017     |
+| MONGO_USER                        | The login username for the MongoDB database.            | admin     |
+| PROGRAMME_MEMBERSHIP_SYNCED_QUEUE | The queue URL for Programme Membership sync events.     |           |
+| SENTRY_DSN                        | A Sentry error monitoring Data Source Name. (Optional)  |           |
 
 
 ### Testing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.1.0"
+version = "0.1.1"
 
 configurations {
   compileOnly {
@@ -53,6 +53,12 @@ dependencies {
   val sentryVersion = "7.2.0"
   implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")
+
+  testImplementation("org.springframework.boot:spring-boot-testcontainers")
+  testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("org.testcontainers:localstack")
+  testImplementation("org.testcontainers:mongodb")
+  testImplementation("org.awaitility:awaitility")
 }
 
 java {

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/RecordEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/RecordEvent.java
@@ -24,6 +24,7 @@ package uk.nhs.tis.trainee.actions.event;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.Getter;
 
 /**
@@ -32,7 +33,9 @@ import lombok.Getter;
 @Getter
 public abstract class RecordEvent {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+      .findAndAddModules()
+      .build();
 
   private Operation operation;
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/DockerImageNames.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/DockerImageNames.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Constants for {@link DockerImageName} values used in tests to ensure consistency.
+ */
+public class DockerImageNames {
+
+  public static final DockerImageName LOCALSTACK = DockerImageName.parse("localstack/localstack:3");
+  public static final DockerImageName MONGO = DockerImageName.parse("mongo:5");
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
@@ -1,0 +1,157 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+import static uk.nhs.tis.trainee.actions.event.Operation.CREATE;
+import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
+import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.actions.DockerImageNames;
+import uk.nhs.tis.trainee.actions.model.Action;
+import uk.nhs.tis.trainee.actions.model.Action.TisReferenceInfo;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+class ProgrammeMembershipListenerIntegrationTest {
+
+  private static final String PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID().toString();
+  private static final LocalDate START_DATE = LocalDate.now();
+
+  private static final String PROGRAMME_MEMBERSHIP_SYNCED_QUEUE = UUID.randomUUID().toString();
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Container
+  private static final LocalStackContainer localstack = new LocalStackContainer(
+      DockerImageNames.LOCALSTACK)
+      .withServices(SQS);
+
+  @DynamicPropertySource
+  private static void overrideProperties(DynamicPropertyRegistry registry) {
+    registry.add("application.queues.programme-membership-synced",
+        () -> PROGRAMME_MEMBERSHIP_SYNCED_QUEUE);
+
+    registry.add("spring.cloud.aws.region.static", localstack::getRegion);
+    registry.add("spring.cloud.aws.credentials.access-key", localstack::getAccessKey);
+    registry.add("spring.cloud.aws.credentials.secret-key", localstack::getSecretKey);
+    registry.add("spring.cloud.aws.sqs.endpoint",
+        () -> localstack.getEndpointOverride(SQS).toString());
+  }
+
+  @BeforeAll
+  static void setUpBeforeAll() throws IOException, InterruptedException {
+    localstack.execInContainer("awslocal sqs create-queue --queue-name",
+        PROGRAMME_MEMBERSHIP_SYNCED_QUEUE);
+  }
+
+  @Autowired
+  private SqsTemplate sqsTemplate;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Action.class);
+  }
+
+  @Test
+  void shouldInsertDataReviewActionWhenProgrammeMembershipCreated() throws JsonProcessingException {
+    String traineeId = UUID.randomUUID().toString();
+    String eventString = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "personId": "%s",
+              "startDate": "%s"
+            },
+            "operation": "%s"
+          }
+        }""".formatted(PROGRAMME_MEMBERSHIP_ID, traineeId, START_DATE, CREATE);
+
+    JsonNode eventJson = JsonMapper.builder()
+        .build()
+        .readTree(eventString);
+
+    sqsTemplate.send(PROGRAMME_MEMBERSHIP_SYNCED_QUEUE, eventJson);
+
+    Criteria criteria = Criteria.where("traineeId").is(traineeId);
+    Query query = Query.query(criteria);
+    List<Action> actions = new ArrayList<>();
+
+    await()
+        .pollInterval(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(() -> {
+          List<Action> found = mongoTemplate.find(query, Action.class);
+          assertThat("Unexpected action count.", found.size(), is(1));
+          actions.addAll(found);
+        });
+
+    Action action = actions.get(0);
+    assertThat("Unexpected action id.", action.id(), notNullValue());
+    assertThat("Unexpected action type.", action.type(), is(REVIEW_DATA));
+    assertThat("Unexpected trainee id.", action.traineeId(), is(traineeId));
+    assertThat("Unexpected due date.", action.due(), is(START_DATE));
+    assertThat("Unexpected completed date.", action.completed(), nullValue());
+
+    TisReferenceInfo tisReference = action.tisReferenceInfo();
+    assertThat("Unexpected TIS id.", tisReference.id(), is(PROGRAMME_MEMBERSHIP_ID));
+    assertThat("Unexpected TIS type.", tisReference.type(), is(PROGRAMME_MEMBERSHIP));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +56,9 @@ class ProgrammeMembershipListenerTest {
   void setUp() {
     service = mock(ActionService.class);
     listener = new ProgrammeMembershipListener(service);
-    mapper = new ObjectMapper().findAndRegisterModules();
+    mapper = JsonMapper.builder()
+        .findAndAddModules()
+        .build();
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceIntegrationTest.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.nhs.tis.trainee.actions.event.Operation.CREATE;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.actions.DockerImageNames;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.model.Action;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers(disabledWithoutDocker = true)
+class ActionServiceIntegrationTest {
+
+  private static final String TIS_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID_1 = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID_2 = UUID.randomUUID().toString();
+  private static final LocalDate START_DATE = LocalDate.now().minusDays(1);
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @Autowired
+  private ActionService service;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Action.class);
+  }
+
+  @Test
+  void shouldNotInsertDuplicateActions() {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID_1, START_DATE);
+
+    service.updateActions(CREATE, dto);
+    assertThrows(DuplicateKeyException.class, () -> service.updateActions(CREATE, dto));
+
+    Criteria criteria = Criteria.where("traineeId").is(TRAINEE_ID_1);
+    Query query = Query.query(criteria);
+    List<Action> actions = mongoTemplate.find(query, Action.class);
+    assertThat("Unexpected action count.", actions.size(), is(1));
+  }
+
+  @Test
+  void shouldNotInsertTheSameActionForMultipleTrainees() {
+    ProgrammeMembershipDto dto1 = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID_1, START_DATE);
+    ProgrammeMembershipDto dto2 = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID_2, START_DATE);
+
+    service.updateActions(CREATE, dto1);
+    assertThrows(DuplicateKeyException.class, () -> service.updateActions(CREATE, dto2));
+
+    Criteria criteria1 = Criteria.where("traineeId").is(TRAINEE_ID_1);
+    Query query1 = Query.query(criteria1);
+    List<Action> actions1 = mongoTemplate.find(query1, Action.class);
+    assertThat("Unexpected action count.", actions1.size(), is(1));
+
+    Criteria criteria2 = Criteria.where("traineeId").is(TRAINEE_ID_2);
+    Query query2 = Query.query(criteria2);
+    List<Action> actions2 = mongoTemplate.find(query2, Action.class);
+    assertThat("Unexpected action count.", actions2.size(), is(0));
+  }
+}


### PR DESCRIPTION
Create integration tests for the ActionService and ProgrammeMembershipListener.

Use Testcontainers to spin up Localstack for SQS and MongoDB using the improved integration in Spring Boot 3.0.

Awaitility will allow time for the SQSListener to pick up the sent message before trying to perform assertions on the result.

TIS21-5582
TIS21-5664