### PR TITLE
chore: increase task memory

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -70,5 +70,5 @@
   "taskRoleArn": "tis-trainee-actions_task-role_${environment}",
   "networkMode": "awsvpc",
   "cpu": "256",
-  "memory": "512"
+  "memory": "1024"
 }


### PR DESCRIPTION
The task memory is too low for the container to correct start, increase it from 512 to 1024.

TIS21-5582