### PR TITLE
feat: add endpoint to mark action completed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.2.0"
+version = "0.3.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -21,10 +21,11 @@
 
 package uk.nhs.tis.trainee.actions.mapper;
 
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants.ComponentModel;
 import uk.nhs.tis.trainee.actions.dto.ActionDto;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
 import uk.nhs.tis.trainee.actions.model.Action;
@@ -34,7 +35,7 @@ import uk.nhs.tis.trainee.actions.model.ActionType;
 /**
  * A mapper to convert to and between Action data types.
  */
-@Mapper(componentModel = ComponentModel.SPRING)
+@Mapper(componentModel = SPRING)
 public interface ActionMapper {
 
   /**
@@ -44,11 +45,6 @@ public interface ActionMapper {
    * @return The built DTO.
    */
   @Mapping(target = "id", expression = "java(entity.id() == null ? null : entity.id().toString())")
-  @Mapping(target = "type")
-  @Mapping(target = "traineeId")
-  @Mapping(target = "tisReferenceInfo")
-  @Mapping(target = "due")
-  @Mapping(target = "completed")
   ActionDto toDto(Action entity);
 
   /**
@@ -58,6 +54,15 @@ public interface ActionMapper {
    * @return The built DTOs.
    */
   List<ActionDto> toDtos(List<Action> entities);
+
+  /**
+   * Complete the given action, with the timestamp set to the current time.
+   *
+   * @param action The action to complete.
+   * @return The completed action.
+   */
+  @Mapping(target = "completed", expression = "java(java.time.Instant.now())")
+  Action complete(Action action);
 
   /**
    * Create an action using Programme Membership data.

--- a/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
@@ -22,6 +22,7 @@
 package uk.nhs.tis.trainee.actions.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -40,4 +41,13 @@ public interface ActionRepository extends MongoRepository<Action, ObjectId> {
    * @return A list of incomplete actions for the trainee.
    */
   List<Action> findAllByTraineeIdAndCompletedIsNullOrderByDueAsc(String traineeId);
+
+  /**
+   * Find an action by its action ID and associated trainee ID.
+   *
+   * @param id        The ID of the action to find.
+   * @param traineeId The trainee that should be associated with the action.
+   * @return The found trainee action, or empty if not found.
+   */
+  Optional<Action> findByIdAndTraineeId(ObjectId id, String traineeId);
 }

--- a/src/test/java/uk/nhs/tis/trainee/actions/api/ActionResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/api/ActionResourceTest.java
@@ -22,6 +22,7 @@
 package uk.nhs.tis.trainee.actions.api;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -31,6 +32,8 @@ import static org.mockito.Mockito.when;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -39,6 +42,9 @@ import uk.nhs.tis.trainee.actions.dto.ActionDto;
 import uk.nhs.tis.trainee.actions.service.ActionService;
 
 class ActionResourceTest {
+
+  private static final String ACTION_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
 
   private ActionResource controller;
   private ActionService service;
@@ -79,14 +85,14 @@ class ActionResourceTest {
 
   @Test
   void shouldReturnTraineeActionsWhenTraineeIdAvailable() {
-    String payload = String.format("{\"%s\":\"%s\"}", "custom:tisId", "40");
+    String payload = String.format("{\"%s\":\"%s\"}", "custom:tisId", TRAINEE_ID);
     String encodedPayload = Base64.getEncoder()
         .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
     String token = String.format("aa.%s.cc", encodedPayload);
 
     ActionDto dto1 = new ActionDto("1", null, null, null, null, null);
     ActionDto dto2 = new ActionDto("2", null, null, null, null, null);
-    when(service.findIncompleteTraineeActions("40")).thenReturn(List.of(dto1, dto2));
+    when(service.findIncompleteTraineeActions(TRAINEE_ID)).thenReturn(List.of(dto1, dto2));
 
     ResponseEntity<List<ActionDto>> response = controller.getTraineeActions(token);
 
@@ -94,8 +100,71 @@ class ActionResourceTest {
     assertThat("Unexpected response body presence.", response.hasBody(), is(true));
 
     List<ActionDto> actions = response.getBody();
+    assertThat("Unexpected actions.", actions, notNullValue());
     assertThat("Unexpected action count.", actions.size(), is(2));
     assertThat("Unexpected action.", actions.get(0), sameInstance(dto1));
     assertThat("Unexpected action.", actions.get(1), sameInstance(dto2));
+  }
+
+  @Test
+  void shouldReturnBadRequestCompletingActionWhenTokenInvalid() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("[]".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    ResponseEntity<ActionDto> response = controller.completeAction(token, ACTION_ID);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(false));
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldReturnBadRequestCompletingActionWhenNoTraineeIdAvailable() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("{}".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    ResponseEntity<ActionDto> response = controller.completeAction(token, ACTION_ID);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(false));
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenTraineeIdAvailableAndActionNotFound() {
+    String payload = String.format("{\"%s\":\"%s\"}", "custom:tisId", TRAINEE_ID);
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    when(service.complete(TRAINEE_ID, ACTION_ID)).thenReturn(Optional.empty());
+
+    ResponseEntity<ActionDto> response = controller.completeAction(token, ACTION_ID);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(false));
+  }
+
+  @Test
+  void shouldReturnCompletedActionWhenTraineeIdAvailableAndActionFound() {
+    String payload = String.format("{\"%s\":\"%s\"}", "custom:tisId", TRAINEE_ID);
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    ActionDto dto = new ActionDto("1", null, null, null, null, null);
+    when(service.complete(TRAINEE_ID, ACTION_ID)).thenReturn(Optional.of(dto));
+
+    ResponseEntity<ActionDto> response = controller.completeAction(token, ACTION_ID);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(HttpStatus.OK));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(true));
+
+    ActionDto action = response.getBody();
+    assertThat("Unexpected action.", action, sameInstance(dto));
   }
 }


### PR DESCRIPTION
Create a POST endpoint `/api/actions/{id}/complete` to allow an action to be marked as completed.
The action must exist and belong to the authenticated trainee, otherwise an error will be returned.

TIS21-5582
TIS21-5619