### PR TITLE
Feat/save placement actions

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -9,6 +9,10 @@
           "valueFrom": "/tis/monitoring/xray/daemon-host"
         },
         {
+          "name": "PLACEMENT_SYNCED_QUEUE",
+          "valueFrom": "/tis/trainee/actions/${environment}/queue-url/placement/synced"
+        },
+        {
           "name": "PROGRAMME_MEMBERSHIP_SYNCED_QUEUE",
           "valueFrom": "/tis/trainee/actions/${environment}/queue-url/programme-membership/synced"
         },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.3.0"
+version = "0.4.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/PlacementListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/PlacementListenerIntegrationTest.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+import static uk.nhs.tis.trainee.actions.event.Operation.CREATE;
+import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
+import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PLACEMENT;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.actions.DockerImageNames;
+import uk.nhs.tis.trainee.actions.model.Action;
+import uk.nhs.tis.trainee.actions.model.Action.TisReferenceInfo;
+
+@SpringBootTest
+@Testcontainers
+class PlacementListenerIntegrationTest {
+
+  private static final String PLACEMENT_ID = UUID.randomUUID().toString();
+  private static final LocalDate START_DATE = LocalDate.now();
+
+  private static final String PLACEMENT_SYNCED_QUEUE = UUID.randomUUID().toString();
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Container
+  private static final LocalStackContainer localstack = new LocalStackContainer(
+      DockerImageNames.LOCALSTACK)
+      .withServices(SQS);
+
+  @DynamicPropertySource
+  private static void overrideProperties(DynamicPropertyRegistry registry) {
+    registry.add("application.queues.placement-synced",
+        () -> PLACEMENT_SYNCED_QUEUE);
+
+    registry.add("spring.cloud.aws.region.static", localstack::getRegion);
+    registry.add("spring.cloud.aws.credentials.access-key", localstack::getAccessKey);
+    registry.add("spring.cloud.aws.credentials.secret-key", localstack::getSecretKey);
+    registry.add("spring.cloud.aws.sqs.endpoint",
+        () -> localstack.getEndpointOverride(SQS).toString());
+    registry.add("spring.cloud.aws.sqs.enabled", () -> true);
+  }
+
+  @BeforeAll
+  static void setUpBeforeAll() throws IOException, InterruptedException {
+    localstack.execInContainer("awslocal sqs create-queue --queue-name",
+        PLACEMENT_SYNCED_QUEUE);
+  }
+
+  @Autowired
+  private SqsTemplate sqsTemplate;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), Action.class);
+  }
+
+  @Test
+  void shouldInsertDataReviewActionWhenPlacementCreated() throws JsonProcessingException {
+    String traineeId = UUID.randomUUID().toString();
+    String eventString = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "traineeId": "%s",
+              "startDate": "%s"
+            },
+            "operation": "%s"
+          }
+        }""".formatted(PLACEMENT_ID, traineeId, START_DATE, CREATE);
+
+    JsonNode eventJson = JsonMapper.builder()
+        .build()
+        .readTree(eventString);
+
+    sqsTemplate.send(PLACEMENT_SYNCED_QUEUE, eventJson);
+
+    Criteria criteria = Criteria.where("traineeId").is(traineeId);
+    Query query = Query.query(criteria);
+    List<Action> actions = new ArrayList<>();
+
+    await()
+        .pollInterval(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(() -> {
+          List<Action> found = mongoTemplate.find(query, Action.class);
+          assertThat("Unexpected action count.", found.size(), is(1));
+          actions.addAll(found);
+        });
+
+    Action action = actions.get(0);
+    assertThat("Unexpected action id.", action.id(), notNullValue());
+    assertThat("Unexpected action type.", action.type(), is(REVIEW_DATA));
+    assertThat("Unexpected trainee id.", action.traineeId(), is(traineeId));
+    assertThat("Unexpected due date.", action.due(), is(START_DATE.minusWeeks(12)));
+    assertThat("Unexpected completed date.", action.completed(), nullValue());
+
+    TisReferenceInfo tisReference = action.tisReferenceInfo();
+    assertThat("Unexpected TIS id.", tisReference.id(), is(PLACEMENT_ID));
+    assertThat("Unexpected TIS type.", tisReference.type(), is(PLACEMENT));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/PlacementListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/PlacementListenerIntegrationTest.java
@@ -118,7 +118,8 @@ class PlacementListenerIntegrationTest {
             "data": {
               "tisId": "%s",
               "traineeId": "%s",
-              "dateFrom": "%s"
+              "dateFrom": "%s",
+              "placementType": "In post"
             },
             "operation": "%s"
           }

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/PlacementListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/PlacementListenerIntegrationTest.java
@@ -118,7 +118,7 @@ class PlacementListenerIntegrationTest {
             "data": {
               "tisId": "%s",
               "traineeId": "%s",
-              "startDate": "%s"
+              "dateFrom": "%s"
             },
             "operation": "%s"
           }

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/PlacementDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/PlacementDto.java
@@ -19,12 +19,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.model;
+package uk.nhs.tis.trainee.actions.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDate;
 
 /**
- * An enumeration of possible TIS reference (core entity) types.
+ * A representation of a placement.
+ *
+ * @param id        The placement ID.
+ * @param traineeId The trainee ID associated with the placement.
+ * @param startDate The placement start date.
  */
-public enum TisReferenceType {
-  PLACEMENT,
-  PROGRAMME_MEMBERSHIP
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PlacementDto(@JsonAlias("tisId") String id, String traineeId,
+                           @JsonAlias("dateFrom") LocalDate startDate) {
+
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/PlacementDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/PlacementDto.java
@@ -28,12 +28,13 @@ import java.time.LocalDate;
 /**
  * A representation of a placement.
  *
- * @param id        The placement ID.
- * @param traineeId The trainee ID associated with the placement.
- * @param startDate The placement start date.
+ * @param id            The placement ID.
+ * @param traineeId     The trainee ID associated with the placement.
+ * @param startDate     The placement start date.
+ * @param placementType The placement type.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PlacementDto(@JsonAlias("tisId") String id, String traineeId,
-                           @JsonAlias("dateFrom") LocalDate startDate) {
+                           @JsonAlias("dateFrom") LocalDate startDate, String placementType) {
 
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/PlacementEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/PlacementEvent.java
@@ -19,12 +19,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.model;
+package uk.nhs.tis.trainee.actions.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 
 /**
- * An enumeration of possible TIS reference (core entity) types.
+ * A placement event.
  */
-public enum TisReferenceType {
-  PLACEMENT,
-  PROGRAMME_MEMBERSHIP
+@Getter
+public class PlacementEvent extends RecordEvent {
+
+  private PlacementDto placement;
+
+  @Override
+  protected void unpackData(JsonNode data) {
+    placement = getObjectMapper().convertValue(data, PlacementDto.class);
+  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/PlacementListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/PlacementListener.java
@@ -28,7 +28,7 @@ import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.service.ActionService;
 
 /**
- * A listener for programme membership events.
+ * A listener for placement events.
  */
 @Slf4j
 @Component

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -21,13 +21,11 @@
 
 package uk.nhs.tis.trainee.actions.mapper;
 
-import java.time.LocalDate;
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingConstants.ComponentModel;
 import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.dto.ActionDto;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
@@ -100,7 +98,7 @@ public interface ActionMapper {
    * @return The created action.
    */
   @Mapping(target = "id", ignore = true)
-  @Mapping(target = "type", source = "type")
+  @Mapping(target = "type")
   @Mapping(target = "traineeId", source = "dto.traineeId")
   @Mapping(target = "tisReferenceInfo", source = "dto")
   @Mapping(target = "due", expression = "java( dto.startDate() != null ? dto.startDate().minusWeeks(12) : null )")

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -21,11 +21,14 @@
 
 package uk.nhs.tis.trainee.actions.mapper;
 
+import java.time.LocalDate;
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.dto.ActionDto;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
 import uk.nhs.tis.trainee.actions.model.Action;
@@ -88,4 +91,29 @@ public interface ActionMapper {
   @Mapping(target = "id", source = "dto.id")
   @Mapping(target = "type", constant = "PROGRAMME_MEMBERSHIP")
   TisReferenceInfo map(ProgrammeMembershipDto dto);
+
+  /**
+   * Create an action using Placement data.
+   *
+   * @param dto  The Placement to retrieve data from.
+   * @param type The type of action to be created.
+   * @return The created action.
+   */
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "type", source = "type")
+  @Mapping(target = "traineeId", source = "dto.traineeId")
+  @Mapping(target = "tisReferenceInfo", source = "dto")
+  @Mapping(target = "due", expression = "java( dto.startDate() != null ? dto.startDate().minusWeeks(12) : null )")
+  @Mapping(target = "completed", ignore = true)
+  Action toAction(PlacementDto dto, ActionType type);
+
+  /**
+   * Map a Placement to a TIS reference info object.
+   *
+   * @param dto The Placement to map.
+   * @return A reference to the TIS core object.
+   */
+  @Mapping(target = "id", source = "dto.id")
+  @Mapping(target = "type", constant = "PLACEMENT")
+  TisReferenceInfo map(PlacementDto dto);
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -26,8 +26,8 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.dto.ActionDto;
+import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
 import uk.nhs.tis.trainee.actions.model.Action;
 import uk.nhs.tis.trainee.actions.model.Action.TisReferenceInfo;
@@ -81,16 +81,6 @@ public interface ActionMapper {
   Action toAction(ProgrammeMembershipDto dto, ActionType type);
 
   /**
-   * Map a Programme Membership to a TIS reference info object.
-   *
-   * @param dto The Programme Membership to map.
-   * @return A reference to the TIS core object.
-   */
-  @Mapping(target = "id", source = "dto.id")
-  @Mapping(target = "type", constant = "PROGRAMME_MEMBERSHIP")
-  TisReferenceInfo map(ProgrammeMembershipDto dto);
-
-  /**
    * Create an action using Placement data.
    *
    * @param dto  The Placement to retrieve data from.
@@ -101,9 +91,20 @@ public interface ActionMapper {
   @Mapping(target = "type")
   @Mapping(target = "traineeId", source = "dto.traineeId")
   @Mapping(target = "tisReferenceInfo", source = "dto")
-  @Mapping(target = "due", expression = "java( dto.startDate() != null ? dto.startDate().minusWeeks(12) : null )")
+  @Mapping(target = "due",
+      expression = "java( dto.startDate() != null ? dto.startDate().minusWeeks(12) : null )")
   @Mapping(target = "completed", ignore = true)
   Action toAction(PlacementDto dto, ActionType type);
+
+  /**
+   * Map a Programme Membership to a TIS reference info object.
+   *
+   * @param dto The Programme Membership to map.
+   * @return A reference to the TIS core object.
+   */
+  @Mapping(target = "id", source = "dto.id")
+  @Mapping(target = "type", constant = "PROGRAMME_MEMBERSHIP")
+  TisReferenceInfo map(ProgrammeMembershipDto dto);
 
   /**
    * Map a Placement to a TIS reference info object.

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -45,6 +45,9 @@ import uk.nhs.tis.trainee.actions.repository.ActionRepository;
 @Service
 public class ActionService {
 
+  public static final List<String> PLACEMENT_TYPES_TO_ACT_ON
+      = List.of("In post", "In post - Acting up", "In Post - Extension");
+
   private final ActionRepository repository;
   private final ActionMapper mapper;
 
@@ -64,8 +67,12 @@ public class ActionService {
     List<Action> actions = new ArrayList<>();
 
     if (Objects.equals(operation, Operation.CREATE)) {
-      Action action = mapper.toAction(dto, REVIEW_DATA);
-      actions.add(action);
+      if (PLACEMENT_TYPES_TO_ACT_ON.stream().anyMatch(dto.placementType()::equalsIgnoreCase)) {
+        Action action = mapper.toAction(dto, REVIEW_DATA);
+        actions.add(action);
+      } else {
+        log.info("Placement {} of type {} is ignored", dto.id(), dto.placementType());
+      }
     }
 
     if (actions.isEmpty()) {

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import uk.nhs.tis.trainee.actions.dto.ActionDto;
+import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
 import uk.nhs.tis.trainee.actions.event.Operation;
 import uk.nhs.tis.trainee.actions.mapper.ActionMapper;
@@ -50,6 +51,30 @@ public class ActionService {
   public ActionService(ActionRepository repository, ActionMapper mapper) {
     this.repository = repository;
     this.mapper = mapper;
+  }
+
+  /**
+   * Updates the actions associated with the given Operation and Placement data.
+   *
+   * @param operation The operation that triggered the update.
+   * @param dto       The Placement data associated with the operation.
+   * @return A list of updated actions, empty if no actions required.
+   */
+  public List<Action> updateActions(Operation operation, PlacementDto dto) {
+    List<Action> actions = new ArrayList<>();
+
+    if (Objects.equals(operation, Operation.CREATE)) {
+      Action action = mapper.toAction(dto, REVIEW_DATA);
+      actions.add(action);
+    }
+
+    if (actions.isEmpty()) {
+      log.info("No new actions required for Placement {}", dto.id());
+      return List.of();
+    }
+
+    log.info("Adding {} new action(s) for Placement {}.", actions.size(), dto.id());
+    return repository.insert(actions);
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -60,7 +60,7 @@ public class ActionService {
    * @param dto       The Placement data associated with the operation.
    * @return A list of updated actions, empty if no actions required.
    */
-  public List<Action> updateActions(Operation operation, PlacementDto dto) {
+  public List<ActionDto> updateActions(Operation operation, PlacementDto dto) {
     List<Action> actions = new ArrayList<>();
 
     if (Objects.equals(operation, Operation.CREATE)) {
@@ -74,7 +74,7 @@ public class ActionService {
     }
 
     log.info("Adding {} new action(s) for Placement {}.", actions.size(), dto.id());
-    return repository.insert(actions);
+    return mapper.toDtos(repository.insert(actions));
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 application:
   environment: ${ENVIRONMENT:local}
   queues:
+    placement-synced: ${PLACEMENT_SYNCED_QUEUE}
     programme-membership-synced: ${PROGRAMME_MEMBERSHIP_SYNCED_QUEUE}
 
 com:

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/PlacementListenerTest.java
@@ -69,7 +69,7 @@ class PlacementListenerTest {
             "data": {
               "tisId": "%s",
               "traineeId": "%s",
-              "startDate": "%s"
+              "dateFrom": "%s"
             }
           }
         }""".formatted(PLACEMENT_ID, TRAINEE_ID, START_DATE);
@@ -102,7 +102,7 @@ class PlacementListenerTest {
             "data": {
               "tisId": "%s",
               "traineeId": "%s",
-              "startDate": "%s"
+              "dateFrom": "%s"
             },
             "operation": "%s"
           }

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/PlacementListenerTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.tis.trainee.actions.dto.PlacementDto;
+import uk.nhs.tis.trainee.actions.service.ActionService;
+
+class PlacementListenerTest {
+
+  private static final String PLACEMENT_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final LocalDate START_DATE = LocalDate.now();
+
+  private PlacementListener listener;
+  private ActionService service;
+
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(ActionService.class);
+    listener = new PlacementListener(service);
+    mapper = JsonMapper.builder()
+        .findAndAddModules()
+        .build();
+  }
+
+  @Test
+  void shouldThrowExceptionWhenSyncEventOperationNull() throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "traineeId": "%s",
+              "startDate": "%s"
+            }
+          }
+        }""".formatted(PLACEMENT_ID, TRAINEE_ID, START_DATE);
+    PlacementEvent event = mapper.readValue(eventJson, PlacementEvent.class);
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handlePlacementSync(event));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Operation.class)
+  void shouldThrowExceptionWhenSyncEventDataNull(Operation operation)
+      throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "operation": "%s"
+          }
+        }""".formatted(operation);
+    PlacementEvent event = mapper.readValue(eventJson, PlacementEvent.class);
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handlePlacementSync(event));
+  }
+
+  @ParameterizedTest
+  @EnumSource(Operation.class)
+  void shouldUpdateActionsWhenSyncEventValid(Operation operation) throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "traineeId": "%s",
+              "startDate": "%s"
+            },
+            "operation": "%s"
+          }
+        }""".formatted(PLACEMENT_ID, TRAINEE_ID, START_DATE, operation);
+    PlacementEvent event = mapper.readValue(eventJson, PlacementEvent.class);
+
+    listener.handlePlacementSync(event);
+
+    ArgumentCaptor<PlacementDto> dtoCaptor = ArgumentCaptor.forClass(PlacementDto.class);
+    verify(service).updateActions(eq(operation), dtoCaptor.capture());
+
+    PlacementDto dto = dtoCaptor.getValue();
+    assertThat("Unexpected ID", dto.id(), is(PLACEMENT_ID));
+    assertThat("Unexpected trainee ID", dto.traineeId(), is(TRAINEE_ID));
+    assertThat("Unexpected start date", dto.startDate(), is(START_DATE));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/PlacementListenerTest.java
@@ -69,7 +69,8 @@ class PlacementListenerTest {
             "data": {
               "tisId": "%s",
               "traineeId": "%s",
-              "dateFrom": "%s"
+              "dateFrom": "%s",
+              "placementType": "In post"
             }
           }
         }""".formatted(PLACEMENT_ID, TRAINEE_ID, START_DATE);
@@ -102,7 +103,8 @@ class PlacementListenerTest {
             "data": {
               "tisId": "%s",
               "traineeId": "%s",
-              "dateFrom": "%s"
+              "dateFrom": "%s",
+              "placementType": "In post"
             },
             "operation": "%s"
           }


### PR DESCRIPTION
Save received placements from the queue as actions.

Note: the 'due' calculation is ugly and will be refactored, but I've left it in at this point, since the DTO rework to include actionableDate etc is still being clarified (as per https://hee-nhs-tis.slack.com/archives/C03G3UK3U82/p1707233150697329)

There is rather too much copy-paste overloaded functions to feel like this is a very elegant PR, but I wasn't up for (premature?) re-engineering (or I'm just tired!)

TIS21-5620