### PR TITLE
fix: respond to INSERT events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.6.0"
+version = "0.6.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/Operation.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/Operation.java
@@ -26,5 +26,5 @@ package uk.nhs.tis.trainee.actions.event;
  */
 public enum Operation {
 
-  CREATE, DELETE, LOAD, UPDATE
+  CREATE, INSERT, DELETE, LOAD, UPDATE
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -122,7 +122,7 @@ public class ActionService {
   public List<ActionDto> updateActions(Operation operation, ProgrammeMembershipDto dto) {
     List<Action> actions = new ArrayList<>();
 
-    if (Objects.equals(operation, Operation.CREATE)) {
+    if (isProgrammeMembershipOperationANewRecord(operation)) {
       Action action = mapper.toAction(dto, REVIEW_DATA);
       actions.add(action);
     }
@@ -183,13 +183,26 @@ public class ActionService {
   }
 
   /**
-   * Determine if an operation means an update for a placement record.
+   * Determine if an operation means an update or new record for a placement.
    *
    * @param operation The operation.
-   * @return True if it means an update for a placement, otherwise false.
+   * @return True if it means an update or new record for a placement, otherwise false.
    */
   private boolean isPlacementOperationAnUpdate(Operation operation) {
-    return Objects.equals(operation, Operation.LOAD) || Objects.equals(operation, Operation.UPDATE);
+    return Objects.equals(operation, Operation.LOAD) ||
+        Objects.equals(operation, Operation.UPDATE) ||
+        Objects.equals(operation, Operation.INSERT);
+  }
+
+  /**
+   * Determine if an operation means a new record for a programme membership record.
+   *
+   * @param operation The operation.
+   * @return True if it means a new record for a programme membership, otherwise false.
+   */
+  private boolean isProgrammeMembershipOperationANewRecord(Operation operation) {
+    return Objects.equals(operation, Operation.CREATE) ||
+        Objects.equals(operation, Operation.INSERT);
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -69,7 +69,7 @@ public class ActionService {
 
     Action action = mapper.toAction(dto, REVIEW_DATA);
 
-    if (isPlacementOperationAnUpdate(operation)) {
+    if (isPlacementOperationAnUpdateOrNew(operation)) {
       if (PLACEMENT_TYPES_TO_ACT_ON.stream().anyMatch(dto.placementType()::equalsIgnoreCase)) {
         //find if action already exists (there should only be at most one)
         List<Action> existingActions = repository.findByTraineeIdAndTisReferenceInfo(
@@ -122,7 +122,7 @@ public class ActionService {
   public List<ActionDto> updateActions(Operation operation, ProgrammeMembershipDto dto) {
     List<Action> actions = new ArrayList<>();
 
-    if (isProgrammeMembershipOperationANewRecord(operation)) {
+    if (isProgrammeMembershipOperationaNewRecord(operation)) {
       Action action = mapper.toAction(dto, REVIEW_DATA);
       actions.add(action);
     }
@@ -188,10 +188,11 @@ public class ActionService {
    * @param operation The operation.
    * @return True if it means an update or new record for a placement, otherwise false.
    */
-  private boolean isPlacementOperationAnUpdate(Operation operation) {
-    return Objects.equals(operation, Operation.LOAD) ||
-        Objects.equals(operation, Operation.UPDATE) ||
-        Objects.equals(operation, Operation.INSERT);
+  private boolean isPlacementOperationAnUpdateOrNew(Operation operation) {
+    return Objects.equals(operation, Operation.LOAD)
+        || Objects.equals(operation, Operation.UPDATE)
+        || Objects.equals(operation, Operation.CREATE)
+        || Objects.equals(operation, Operation.INSERT);
   }
 
   /**
@@ -200,9 +201,9 @@ public class ActionService {
    * @param operation The operation.
    * @return True if it means a new record for a programme membership, otherwise false.
    */
-  private boolean isProgrammeMembershipOperationANewRecord(Operation operation) {
-    return Objects.equals(operation, Operation.CREATE) ||
-        Objects.equals(operation, Operation.INSERT);
+  private boolean isProgrammeMembershipOperationaNewRecord(Operation operation) {
+    return Objects.equals(operation, Operation.CREATE)
+        || Objects.equals(operation, Operation.INSERT);
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -250,18 +250,7 @@ class ActionServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE", "INSERT", "DELETE"},
-      mode = EXCLUDE)
-  void shouldNotInsertActionWhenPlacementOperationNotSupported(Operation operation) {
-    PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, FUTURE, PLACEMENT_TYPE);
-
-    service.updateActions(operation, dto);
-
-    verifyNoInteractions(repository);
-  }
-
-  @ParameterizedTest
-  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE", "INSERT"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE", "INSERT", "CREATE"})
   void shouldInsertActionWhenPlacementOperationSupported(Operation operation) {
     PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, FUTURE, PLACEMENT_TYPE);
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -84,7 +84,7 @@ class ActionServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = Operation.class, names = {"CREATE"}, mode = EXCLUDE)
+  @EnumSource(value = Operation.class, names = {"CREATE", "INSERT"}, mode = EXCLUDE)
   void shouldNotInsertActionWhenProgrammeMembershipOperationNotSupported(Operation operation) {
     ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, FUTURE);
 
@@ -93,13 +93,14 @@ class ActionServiceTest {
     verifyNoInteractions(repository);
   }
 
-  @Test
-  void shouldInsertReviewDataActionOnProgrammeMembershipCreate() {
+  @ParameterizedTest
+  @EnumSource(value = Operation.class, names = {"CREATE", "INSERT"})
+  void shouldInsertReviewDataActionOnProgrammeMembershipCreate(Operation operation) {
     ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, FUTURE);
 
     when(repository.insert(anyIterable())).thenAnswer(inv -> inv.getArgument(0));
 
-    List<ActionDto> actions = service.updateActions(Operation.CREATE, dto);
+    List<ActionDto> actions = service.updateActions(operation, dto);
 
     assertThat("Unexpected action count.", actions.size(), is(1));
 
@@ -249,7 +250,8 @@ class ActionServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE", "DELETE"}, mode = EXCLUDE)
+  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE", "INSERT", "DELETE"},
+      mode = EXCLUDE)
   void shouldNotInsertActionWhenPlacementOperationNotSupported(Operation operation) {
     PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, FUTURE, PLACEMENT_TYPE);
 
@@ -259,7 +261,7 @@ class ActionServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "UPDATE", "INSERT"})
   void shouldInsertActionWhenPlacementOperationSupported(Operation operation) {
     PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, FUTURE, PLACEMENT_TYPE);
 


### PR DESCRIPTION
The events from tis-trainee-sync come as operation=INSERT not operation=CREATE. This is NB for handling programme memberships.

Also amend placement handling to react to initial insert as well as updates.

(Looking on prod, there is only one test programme membership action at this point, so we are definitely missing these)

I think this bug slipped through because of challenges in seeing the complete flow on staging with the DMS disabled, not that that justifies it 🤕 

NO-TICKET