### PR TITLE
fix: respond to LOAD events

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.6.1"
+version = "0.6.2"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
Only variation from agreed rules is that if a delete event arrives before an existing action has been completed, the existing action is deleted. This is because there would be no way for the trainee to complete the action, since the now-deleted programme membership would not be shown on their profile.

TIS21-5792
TIS21-5807