### PR TITLE
chore: disable Sentry on preprod

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -56,6 +56,10 @@
       ],
       "environment": [
         {
+          "name": "SPRING_PROFILES_ACTIVE",
+          "value": "${environment}"
+        },
+        {
           "name": "TITLE",
           "value": "tis-trainee-actions"
         },

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -1,0 +1,2 @@
+sentry:
+  enabled: false


### PR DESCRIPTION
The preprod service is creating a large amount of Sentry errors due to duplicate indexes.
Until there is an answer/solution to the problem Sentry reporting should be disabled to avoid using up all of our allowance.

Create properties for a `preprod` profile which disables sentry. Update the task definition to set the `SPRING_PROFILES_ACTIVE` env var based on the environment.

NO-TICKET