### PR TITLE
Feat/programme and trainee actions

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -39,6 +39,10 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "tis-trainee-actions-sentry-dsn"
+        },
+        {
+          "name": "ACCOUNT_CONFIRMED_QUEUE",
+          "valueFrom": "/tis/trainee/actions/${environment}/queue-url/account/confirmed"
         }
       ],
       "logConfiguration": {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.9.2"
+version = "0.10.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/repository/ActionRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/repository/ActionRepositoryIntegrationTest.java
@@ -130,7 +130,7 @@ class ActionRepositoryIntegrationTest {
 
     List<Action> deletedActions = repository.deleteByTraineeIdAndTisReferenceInfoAndNotComplete(
         TRAINEE_ID_1, TIS_ID, PLACEMENT.toString());
-    assertThat("Unexpected delete count.", deletedActions.size(), is(0L));
+    assertThat("Unexpected delete count.", deletedActions.size(), is(0));
   }
 
   @Test
@@ -143,7 +143,7 @@ class ActionRepositoryIntegrationTest {
 
     List<Action> deletedActions = repository.deleteByTraineeIdAndTisReferenceInfoAndNotComplete(
         TRAINEE_ID_1, TIS_ID, PLACEMENT.toString());
-    assertThat("Unexpected delete count.", deletedActions.size(), is(1L));
+    assertThat("Unexpected delete count.", deletedActions.size(), is(1));
   }
 
   @ParameterizedTest
@@ -158,6 +158,6 @@ class ActionRepositoryIntegrationTest {
 
     List<Action> deletedActions = repository.deleteByTraineeIdAndTisReferenceInfo(
         TRAINEE_ID_1, TIS_ID, PLACEMENT.toString());
-    assertThat("Unexpected delete count.", deletedActions.size(), is(1L));
+    assertThat("Unexpected delete count.", deletedActions.size(), is(1));
   }
 }

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -6,6 +6,9 @@ application:
   sns:
     arn: dummy
 
+mongock:
+  enabled: false
+
 spring:
   cloud:
     aws:

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -1,7 +1,10 @@
 application:
   queues:
+    account-confirmed: dummy
     placement-synced: dummy
     programme-membership-synced: dummy
+  sns:
+    arn: dummy.fifo
 
 spring:
   cloud:

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -4,7 +4,7 @@ application:
     placement-synced: dummy
     programme-membership-synced: dummy
   sns:
-    arn: dummy.fifo
+    arn: dummy
 
 spring:
   cloud:

--- a/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
@@ -106,7 +106,7 @@ public class ActionResource {
       return ResponseEntity.badRequest().build();
     }
 
-    Optional<ActionDto> action = service.complete(traineeId, actionId);
+    Optional<ActionDto> action = service.completeAsUser(traineeId, actionId);
     return ResponseEntity.of(action);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/AccountConfirmedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/AccountConfirmedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2024 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,43 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.model;
+package uk.nhs.tis.trainee.actions.dto;
 
-import java.util.EnumSet;
-import java.util.Set;
-import lombok.Getter;
+import java.util.UUID;
 
 /**
- * The type category of the action to be performed.
+ * An event published when a user account is confirmed.
+ *
+ * @param userId    The user account ID.
+ * @param traineeId The linked trainee ID.
+ * @param email     The user account's email address.
  */
-public enum ActionType {
-  REVIEW_DATA,
-  SIGN_COJ,
-  SIGN_FORM_R_PART_A,
-  SIGN_FORM_R_PART_B,
-  REGISTER_TSS;
+public record AccountConfirmedEvent(UUID userId, String traineeId, String email) {
 
-  /**
-   * The set of Programme action types.
-   */
-  @Getter
-  private static final Set<ActionType> programmeActionTypes = EnumSet.of(
-      REVIEW_DATA,
-      SIGN_COJ,
-      SIGN_FORM_R_PART_A,
-      SIGN_FORM_R_PART_B);
-
-  /**
-   * The set of Placement action types.
-   */
-  @Getter
-  private static final Set<ActionType> placementActionTypes = EnumSet.of(
-      REVIEW_DATA);
-
-  /**
-   * The set of Person action types.
-   */
-  @Getter
-  private static final Set<ActionType> personActionTypes = EnumSet.of(
-      REGISTER_TSS);
-  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/UserAccountListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/UserAccountListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2024 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,43 +19,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.actions.model;
+package uk.nhs.tis.trainee.actions.event;
 
-import java.util.EnumSet;
-import java.util.Set;
-import lombok.Getter;
+import static uk.nhs.tis.trainee.actions.event.Operation.LOAD;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.actions.service.ActionService;
+import uk.nhs.tis.trainee.actions.dto.AccountConfirmedEvent;
 
 /**
- * The type category of the action to be performed.
+ * A listener for user account events.
  */
-public enum ActionType {
-  REVIEW_DATA,
-  SIGN_COJ,
-  SIGN_FORM_R_PART_A,
-  SIGN_FORM_R_PART_B,
-  REGISTER_TSS;
+@Slf4j
+@Component
+public class UserAccountListener {
+
+  private final ActionService actionService;
 
   /**
-   * The set of Programme action types.
+   * Construct a listener for user account events.
+   *
+   * @param actionService The action service.
    */
-  @Getter
-  private static final Set<ActionType> programmeActionTypes = EnumSet.of(
-      REVIEW_DATA,
-      SIGN_COJ,
-      SIGN_FORM_R_PART_A,
-      SIGN_FORM_R_PART_B);
-
-  /**
-   * The set of Placement action types.
-   */
-  @Getter
-  private static final Set<ActionType> placementActionTypes = EnumSet.of(
-      REVIEW_DATA);
-
-  /**
-   * The set of Person action types.
-   */
-  @Getter
-  private static final Set<ActionType> personActionTypes = EnumSet.of(
-      REGISTER_TSS);
+  public UserAccountListener(ActionService actionService) {
+    this.actionService = actionService;
   }
+
+  /**
+   * Handle account confirmation events.
+   *
+   * @param event The account confirmation event.
+   */
+  @SqsListener("${application.queues.account-confirmed}")
+  public void handleAccountConfirmation(AccountConfirmedEvent event) {
+    log.info("Handling account confirmation event for user {}.", event.traineeId());
+    actionService.updateActions(LOAD, event);
+  }
+
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/event/UserAccountListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/event/UserAccountListener.java
@@ -22,11 +22,12 @@
 package uk.nhs.tis.trainee.actions.event;
 
 import static uk.nhs.tis.trainee.actions.event.Operation.LOAD;
+
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.nhs.tis.trainee.actions.service.ActionService;
 import uk.nhs.tis.trainee.actions.dto.AccountConfirmedEvent;
+import uk.nhs.tis.trainee.actions.service.ActionService;
 
 /**
  * A listener for user account events.

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -83,6 +83,22 @@ public interface ActionMapper {
   Action toAction(ProgrammeMembershipDto dto, ActionType type);
 
   /**
+   * Create an action using a trainee ID and ActionType.
+   *
+   * @param traineeId The ID of the trainee the action is for.
+   * @param type      The type of action to be created.
+   * @return The created action.
+   */
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "type")
+  @Mapping(target = "traineeId")
+  @Mapping(target = "tisReferenceInfo", ignore = true)
+  @Mapping(target = "availableFrom", expression = "java(java.time.LocalDate.now())")
+  @Mapping(target = "dueBy", ignore = true)
+  @Mapping(target = "completed", ignore = true)
+  Action toAction(String traineeId, ActionType type);
+
+  /**
    * Create an action using Placement data.
    *
    * @param dto  The Placement to retrieve data from.

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -135,7 +135,7 @@ public interface ActionMapper {
    * @return The ActionBroadcastDto.
    */
   @Mapping(target = "id", expression = "java(action.id().toString())")
-  @Mapping(target = "type", ignore = true)
+  @Mapping(target = "type", expression = "java(action.type().toString())")
   @Mapping(target = "traineeId", ignore = true)
   @Mapping(target = "tisReferenceInfo", ignore = true)
   @Mapping(target = "availableFrom", ignore = true)

--- a/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/mapper/ActionMapper.java
@@ -26,6 +26,7 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import uk.nhs.tis.trainee.actions.dto.AccountConfirmedEvent;
 import uk.nhs.tis.trainee.actions.dto.ActionBroadcastDto;
 import uk.nhs.tis.trainee.actions.dto.ActionDto;
 import uk.nhs.tis.trainee.actions.dto.PlacementDto;
@@ -83,20 +84,20 @@ public interface ActionMapper {
   Action toAction(ProgrammeMembershipDto dto, ActionType type);
 
   /**
-   * Create an action using a trainee ID and ActionType.
+   * Create an action using an account event and ActionType.
    *
-   * @param traineeId The ID of the trainee the action is for.
-   * @param type      The type of action to be created.
+   * @param accountEvent The account event.
+   * @param type         The type of action to be created.
    * @return The created action.
    */
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "type")
-  @Mapping(target = "traineeId")
-  @Mapping(target = "tisReferenceInfo", ignore = true)
-  @Mapping(target = "availableFrom", expression = "java(java.time.LocalDate.now())")
+  @Mapping(target = "traineeId", source = "accountEvent.traineeId")
+  @Mapping(target = "tisReferenceInfo", source = "accountEvent")
+  @Mapping(target = "availableFrom", ignore = true)
   @Mapping(target = "dueBy", ignore = true)
-  @Mapping(target = "completed", ignore = true)
-  Action toAction(String traineeId, ActionType type);
+  @Mapping(target = "completed", expression = "java(java.time.Instant.now())")
+  Action toAction(AccountConfirmedEvent accountEvent, ActionType type);
 
   /**
    * Create an action using Placement data.
@@ -163,4 +164,14 @@ public interface ActionMapper {
   @Mapping(target = "id", source = "dto.id")
   @Mapping(target = "type", constant = "PLACEMENT")
   TisReferenceInfo map(PlacementDto dto);
+
+  /**
+   * Map an Account Event to a TIS reference info object.
+   *
+   * @param accountEvent The account event to map.
+   * @return A reference to the TIS core object.
+   */
+  @Mapping(target = "id", source = "accountEvent.traineeId")
+  @Mapping(target = "type", constant = "PERSON")
+  TisReferenceInfo map(AccountConfirmedEvent accountEvent);
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/Action.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/Action.java
@@ -59,4 +59,14 @@ public record Action(
   public record TisReferenceInfo(@Field("id") String id, TisReferenceType type) {
 
   }
+
+  /**
+   * Create a new action with the specified type.
+   *
+   * @param type The new action type.
+   * @return A new Action instance with the specified type.
+   */
+  public Action withType(ActionType type) {
+    return new Action(id, type, traineeId, tisReferenceInfo, availableFrom, dueBy, completed);
+  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/Action.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/Action.java
@@ -59,14 +59,4 @@ public record Action(
   public record TisReferenceInfo(@Field("id") String id, TisReferenceType type) {
 
   }
-
-  /**
-   * Create a new action with the specified type.
-   *
-   * @param type The new action type.
-   * @return A new Action instance with the specified type.
-   */
-  public Action withType(ActionType type) {
-    return new Action(id, type, traineeId, tisReferenceInfo, availableFrom, dueBy, completed);
-  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
@@ -58,4 +58,4 @@ public enum ActionType {
   @Getter
   private static final Set<ActionType> personActionTypes = EnumSet.of(
       REGISTER_TSS);
-  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
@@ -58,4 +58,11 @@ public enum ActionType {
   @Getter
   private static final Set<ActionType> personActionTypes = EnumSet.of(
       REGISTER_TSS);
+
+  /**
+   * The set of user-completable action types.
+   */
+  @Getter
+  private static final Set<ActionType> userCompletableActionTypes = EnumSet.of(
+      REVIEW_DATA);
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
@@ -21,9 +21,41 @@
 
 package uk.nhs.tis.trainee.actions.model;
 
+import java.util.EnumSet;
+import java.util.Set;
+import lombok.Getter;
+
 /**
  * The type category of the action to be performed.
  */
 public enum ActionType {
-  REVIEW_DATA
-}
+  REVIEW_DATA,
+  SIGN_COJ,
+  SIGN_FORM_R_PART_A,
+  SIGN_FORM_R_PART_B,
+  REGISTER_TSS;
+
+  /**
+   * The set of Programme action types.
+   */
+  @Getter
+  private static final Set<ActionType> programmeActionTypes = EnumSet.of(
+      REVIEW_DATA,
+      SIGN_COJ,
+      SIGN_FORM_R_PART_A,
+      SIGN_FORM_R_PART_B);
+
+  /**
+   * The set of Placement action types.
+   */
+  @Getter
+  private static final Set<ActionType> placementActionTypes = EnumSet.of(
+      REVIEW_DATA);
+
+  /**
+   * The set of Trainee action types.
+   */
+  @Getter
+  private static final Set<ActionType> traineeActionTypes = EnumSet.of(
+      REGISTER_TSS);
+  }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/TisReferenceType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/TisReferenceType.java
@@ -26,5 +26,6 @@ package uk.nhs.tis.trainee.actions.model;
  */
 public enum TisReferenceType {
   PLACEMENT,
-  PROGRAMME_MEMBERSHIP
+  PROGRAMME_MEMBERSHIP,
+  PERSON
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
@@ -29,6 +29,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.nhs.tis.trainee.actions.model.Action;
+import uk.nhs.tis.trainee.actions.model.ActionType;
 
 /**
  * A repository of trainee actions.
@@ -78,6 +79,21 @@ public interface ActionRepository extends MongoRepository<Action, ObjectId> {
       + "{'tisReferenceInfo.id': ?1}, "
       + "{'tisReferenceInfo.type': ?2}]}")
   List<Action> deleteByTraineeIdAndTisReferenceInfo(String traineeId, String tisId, String type);
+
+  /**
+   * Delete specific TIS entity action(s) for a trainee.
+   *
+   * @param traineeId  The trainee ID.
+   * @param tisId      The TIS ID of the entity.
+   * @param type       The entity type.
+   * @param actionType The action type to delete.
+   */
+  @DeleteQuery(value = "{$and : [{'traineeId': ?0}, "
+      + "{'tisReferenceInfo.id': ?1}, "
+      + "{'tisReferenceInfo.type': ?2}, "
+      + "{'type': ?3}]}")
+  List<Action> deleteByTraineeIdAndTisReferenceInfoAndActionType(String traineeId, String tisId,
+      String type, ActionType actionType);
 
   /**
    * Find specific TIS entity action(s) for a trainee.

--- a/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
@@ -29,7 +29,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.nhs.tis.trainee.actions.model.Action;
-import uk.nhs.tis.trainee.actions.model.ActionType;
 
 /**
  * A repository of trainee actions.
@@ -81,7 +80,7 @@ public interface ActionRepository extends MongoRepository<Action, ObjectId> {
   List<Action> deleteByTraineeIdAndTisReferenceInfo(String traineeId, String tisId, String type);
 
   /**
-   * Delete specific TIS entity action(s) for a trainee.
+   * Delete specific TIS entity action(s) for a trainee where these are not complete.
    *
    * @param traineeId  The trainee ID.
    * @param tisId      The TIS ID of the entity.
@@ -92,8 +91,8 @@ public interface ActionRepository extends MongoRepository<Action, ObjectId> {
       + "{'tisReferenceInfo.id': ?1}, "
       + "{'tisReferenceInfo.type': ?2}, "
       + "{'type': ?3}]}")
-  List<Action> deleteByTraineeIdAndTisReferenceInfoAndActionType(String traineeId, String tisId,
-      String type, ActionType actionType);
+  List<Action> deleteByTraineeIdAndTisReferenceInfoAndActionType(String traineeId,
+      String tisId, String type, String actionType);
 
   /**
    * Find specific TIS entity action(s) for a trainee.

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -64,7 +64,7 @@ public class ActionService {
    * The constructor of action service.
    */
   public ActionService(ActionRepository repository, ActionMapper mapper,
-                       EventPublishingService eventPublishingService) {
+      EventPublishingService eventPublishingService) {
     this.repository = repository;
     this.mapper = mapper;
     this.eventPublishingService = eventPublishingService;
@@ -207,12 +207,12 @@ public class ActionService {
     }
 
     if (actions.isEmpty()) {
-    log.info("No new actions required for Person account {}", account.traineeId());
-    return List.of();
-  }
+      log.info("No new actions required for Person account {}", account.traineeId());
+      return List.of();
+    }
 
     log.info("Adding {} new action(s) for Person account {}.", actions.size(), account.traineeId());
-  List<Action> actionInserted = repository.insert(actions);
+    List<Action> actionInserted = repository.insert(actions);
     actionInserted.stream().forEach(eventPublishingService::publishActionUpdateEvent);
     return mapper.toDtos(actionInserted);
   }

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -72,6 +72,7 @@ public class ActionService {
 
   /**
    * Add or update actions for a given Placement DTO.
+   *
    * @param dto     The placement DTO.
    * @param actions The list of actions to supplement with new or updated actions.
    */

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -169,7 +169,7 @@ public class ActionService {
     } else if (Objects.equals(operation, Operation.DELETE)) {
       log.info("Programme membership {} is deleted", dto.id());
       Action action = mapper.toAction(dto, REVIEW_DATA);
-      deleteIncompleteActions(action); //will delete all actions for this programme membership
+      deleteIncompleteActions(action);
     }
 
     if (actions.isEmpty()) {

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -272,13 +272,13 @@ public class ActionService {
   }
 
   /**
-   * Complete a trainee's action.
+   * Complete a trainee's action. It must be a user-completable action.
    *
    * @param traineeId The ID of the trainee who owns the action to be completed.
    * @param actionId  The ID of the action to complete.
    * @return The completed action, or empty if not found.
    */
-  public Optional<ActionDto> complete(String traineeId, String actionId) {
+  public Optional<ActionDto> completeAsUser(String traineeId, String actionId) {
     if (!ObjectId.isValid(actionId)) {
       log.info("Skipping action completion due to invalid id.");
       return Optional.empty();
@@ -296,6 +296,12 @@ public class ActionService {
 
     if (action.completed() != null) {
       log.info("Skipping action completion as the action was already complete.");
+      return Optional.empty();
+    }
+
+    if (!ActionType.getUserCompletableActionTypes().contains(action.type())) {
+      log.info("Skipping action completion as the action type {} is not user-completable.",
+          action.type());
       return Optional.empty();
     }
 

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/EventPublishingService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/EventPublishingService.java
@@ -83,10 +83,8 @@ public class EventPublishingService {
 
     SnsNotification<ActionBroadcastDto> message;
     if (topicArn.toString().endsWith(".fifo")) {
-      // Create a message group to ensure FIFO per unique object.
       message = SnsNotification.builder(action).groupId(actionId).build();
     } else {
-      // For non-FIFO topics, we can use the default group ID.
       message = SnsNotification.builder(action).build();
     }
     snsTemplate.sendNotification(topicArn.toString(), message);

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/EventPublishingService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/EventPublishingService.java
@@ -79,7 +79,7 @@ public class EventPublishingService {
    */
   private void publishActionBroadcastEvent(ActionBroadcastDto action) {
     String actionId = action.id();
-    log.info("Publishing {} event for action {}", action.status(), actionId);
+    log.info("Publishing {} event for {} action {}", action.status(), action.type(), actionId);
 
     SnsNotification<ActionBroadcastDto> message;
     if (topicArn.toString().endsWith(".fifo")) {
@@ -88,6 +88,7 @@ public class EventPublishingService {
       message = SnsNotification.builder(action).build();
     }
     snsTemplate.sendNotification(topicArn.toString(), message);
-    log.info("Published {} event for action {} to topic {}", action.status(), actionId, topicArn);
+    log.info("Published {} event for {} action {} to topic {}", action.status(), action.type(),
+        actionId, topicArn);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/EventPublishingService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/EventPublishingService.java
@@ -81,9 +81,14 @@ public class EventPublishingService {
     String actionId = action.id();
     log.info("Publishing {} event for action {}", action.status(), actionId);
 
-    SnsNotification<ActionBroadcastDto> message = SnsNotification.builder(action)
-        .groupId(actionId)
-        .build();
+    SnsNotification<ActionBroadcastDto> message;
+    if (topicArn.toString().endsWith(".fifo")) {
+      // Create a message group to ensure FIFO per unique object.
+      message = SnsNotification.builder(action).groupId(actionId).build();
+    } else {
+      // For non-FIFO topics, we can use the default group ID.
+      message = SnsNotification.builder(action).build();
+    }
     snsTemplate.sendNotification(topicArn.toString(), message);
     log.info("Published {} event for action {} to topic {}", action.status(), actionId, topicArn);
   }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,22 @@
+application:
+  environment: local
+  queues:
+    account-confirmed: ${local.sqs-path}/tis-trainee-actions-local-account-confirmed
+    placement-synced: ${local.sqs-path}/tis-trainee-actions-local-placement-synced
+    programme-membership-synced: ${local.sqs-path}/tis-trainee-actions-local-programme-membership-synced
+  sns:
+    arn: arn:aws:sns:eu-west-2:${local.account-id}:tis-trainee-actions-event
+
+local:
+  account-id: "000000000000"
+  sqs-path: ${spring.cloud.aws.endpoint}/${local.account-id}
+
+spring:
+  cloud:
+    aws:
+      credentials:
+        access-key: ${local.account-id}
+        secret-key: ${local.account-id}
+      endpoint: http://${LOCALSTACK_HOST:localhost}:4566
+      region:
+        static: eu-west-2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 application:
   environment: ${ENVIRONMENT:local}
   queues:
+    account-confirmed: ${ACCOUNT_CONFIRMED_QUEUE}
     placement-synced: ${PLACEMENT_SYNCED_QUEUE}
     programme-membership-synced: ${PROGRAMME_MEMBERSHIP_SYNCED_QUEUE}
   sns:

--- a/src/test/java/uk/nhs/tis/trainee/actions/api/ActionResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/api/ActionResourceTest.java
@@ -141,7 +141,7 @@ class ActionResourceTest {
         .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
     String token = String.format("aa.%s.cc", encodedPayload);
 
-    when(service.complete(TRAINEE_ID, ACTION_ID)).thenReturn(Optional.empty());
+    when(service.completeAsUser(TRAINEE_ID, ACTION_ID)).thenReturn(Optional.empty());
 
     ResponseEntity<ActionDto> response = controller.completeAction(token, ACTION_ID);
 
@@ -157,7 +157,7 @@ class ActionResourceTest {
     String token = String.format("aa.%s.cc", encodedPayload);
 
     ActionDto dto = new ActionDto("1", null, null, null, null, null, null);
-    when(service.complete(TRAINEE_ID, ACTION_ID)).thenReturn(Optional.of(dto));
+    when(service.completeAsUser(TRAINEE_ID, ACTION_ID)).thenReturn(Optional.of(dto));
 
     ResponseEntity<ActionDto> response = controller.completeAction(token, ACTION_ID);
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/event/UserAccountListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/event/UserAccountListenerTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.nhs.tis.trainee.actions.event.Operation.LOAD;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.tis.trainee.actions.dto.AccountConfirmedEvent;
+import uk.nhs.tis.trainee.actions.service.ActionService;
+
+/**
+ * Tests for {@link UserAccountListener}.
+ */
+class UserAccountListenerTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String EMAIL = "some@email.test";
+  private static final UUID USER_ID = UUID.randomUUID();
+
+  private UserAccountListener listener;
+  private ActionService service;
+
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(ActionService.class);
+    listener = new UserAccountListener(service);
+    mapper = JsonMapper.builder()
+        .findAndAddModules()
+        .build();
+  }
+
+  @Test
+  void shouldUpdateActions() throws JsonProcessingException {
+    String eventJson = """
+        {
+          "userId": "%s",
+          "traineeId": "%s",
+          "email": "%s"
+        }""".formatted(USER_ID, TRAINEE_ID, EMAIL);
+    AccountConfirmedEvent event = mapper.readValue(eventJson, AccountConfirmedEvent.class);
+
+    listener.handleAccountConfirmation(event);
+
+    ArgumentCaptor<AccountConfirmedEvent> dtoCaptor
+        = ArgumentCaptor.forClass(AccountConfirmedEvent.class);
+    verify(service).updateActions(eq(LOAD), dtoCaptor.capture());
+
+    AccountConfirmedEvent eventSent = dtoCaptor.getValue();
+    assertThat("Unexpected ID", eventSent.userId(), is(USER_ID));
+    assertThat("Unexpected trainee ID", eventSent.traineeId(), is(TRAINEE_ID));
+    assertThat("Unexpected start date", eventSent.email(), is(EMAIL));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -417,7 +417,6 @@ class ActionServiceTest {
 
   @Test
   void shouldReplacePlacementActionsIfTheyAlreadyExistsWithDifferentDueDateAndPostEpoch() {
-    PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, POST_EPOCH, PLACEMENT_TYPE);
     List<Action> existingActions = new ArrayList<>();
     for (ActionType actionType : ActionType.getPlacementActionTypes()) {
       Action existingAction = new Action(ObjectId.get(), actionType, TRAINEE_ID,
@@ -434,6 +433,7 @@ class ActionServiceTest {
     when(repository.findByTraineeIdAndTisReferenceInfo(TRAINEE_ID, TIS_ID,
         String.valueOf(PLACEMENT))).thenReturn(existingActions);
 
+    PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, POST_EPOCH, PLACEMENT_TYPE);
     List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
 
     int expectedActionCount = ActionType.getPlacementActionTypes().size();
@@ -473,7 +473,8 @@ class ActionServiceTest {
     when(repository.findByTraineeIdAndTisReferenceInfo(TRAINEE_ID, TIS_ID,
         String.valueOf(PLACEMENT))).thenReturn(List.of(existingAction));
     when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionType(TRAINEE_ID, TIS_ID,
-        String.valueOf(PLACEMENT), String.valueOf(REVIEW_DATA))).thenReturn(List.of(existingAction));
+        String.valueOf(PLACEMENT), String.valueOf(REVIEW_DATA)))
+        .thenReturn(List.of(existingAction));
 
     List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -117,11 +117,11 @@ class ActionServiceTest {
     List<Action> actionsPublished = actionCaptor.getAllValues();
 
     for (ActionType actionType : ActionType.getProgrammeActionTypes()) {
-      ActionDto action = actions.stream()
+      Optional<ActionDto> actionOfType = actions.stream()
           .filter(a -> a.type().equals(actionType.toString()))
-          .findFirst()
-          .orElseThrow(() -> new AssertionError("Missing action for type: " + actionType));
-
+          .findFirst();
+      assertThat("Missing action for type: " + actionType, actionOfType.isPresent(), is(true));
+      ActionDto action = actionOfType.get();
       assertThat("Unexpected action id.", action.id(), nullValue());
       assertThat("Unexpected action type.", action.type(), is(actionType.toString()));
       assertThat("Unexpected trainee id.", action.traineeId(), is(TRAINEE_ID));
@@ -134,12 +134,12 @@ class ActionServiceTest {
       assertThat("Unexpected TIS type.", tisReference.type(),
           is(PROGRAMME_MEMBERSHIP));
 
-      Action actionPublished = actionsPublished.stream()
+      Optional<Action> actionPublishedOfType = actionsPublished.stream()
           .filter(a -> a.type().equals(actionType))
-          .findFirst()
-          .orElseThrow(
-              () -> new AssertionError("Missing action published for type: " + actionType));
-
+          .findFirst();
+      assertThat("Missing action for type: " + actionType, actionPublishedOfType.isPresent(),
+          is(true));
+      Action actionPublished = actionPublishedOfType.get();
       assertThat("Unexpected action id.", actionPublished.id(), nullValue());
       assertThat("Unexpected action type.", actionPublished.type(), is(actionType));
       assertThat("Unexpected trainee id.", actionPublished.traineeId(), is(TRAINEE_ID));
@@ -442,11 +442,10 @@ class ActionServiceTest {
     verify(repository).findByTraineeIdAndTisReferenceInfo(TRAINEE_ID, TIS_ID, PLACEMENT.toString());
 
     for (ActionType actionType : ActionType.getPlacementActionTypes()) {
-      ActionDto actionOfType = actions.stream()
+      Optional<ActionDto> actionOfType = actions.stream()
           .filter(a -> a.type().equals(actionType.toString()))
-          .findFirst()
-          .orElseThrow(() -> new AssertionError("Missing action for type: " + actionType));
-
+          .findFirst();
+      assertThat("Missing action for type: " + actionType, actionOfType.isPresent(), is(true));
       verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionType(
           TRAINEE_ID, TIS_ID, PLACEMENT.toString(), actionType.toString());
       ArgumentCaptor<Action> deletedActionCaptor = ArgumentCaptor.forClass(Action.class);
@@ -503,11 +502,11 @@ class ActionServiceTest {
     assertThat("Unexpected action count.", actions.size(), is(expectedActionCount));
 
     for (ActionType actionType : ActionType.getPlacementActionTypes()) {
-      ActionDto action = actions.stream()
+      Optional<ActionDto> actionOfType = actions.stream()
           .filter(a -> a.type().equals(actionType.toString()))
-          .findFirst()
-          .orElseThrow(() -> new AssertionError("Missing action for type: " + actionType));
-
+          .findFirst();
+      assertThat("Missing action for type: " + actionType, actionOfType.isPresent(), is(true));
+      ActionDto action = actionOfType.get();
       assertThat("Unexpected action id.", action.id(), nullValue());
       assertThat("Unexpected action type.", action.type(), is(actionType.toString()));
       assertThat("Unexpected trainee id.", action.traineeId(), is(TRAINEE_ID));
@@ -559,11 +558,11 @@ class ActionServiceTest {
     List<Action> actionsPublished = actionCaptor.getAllValues();
 
     for (ActionType actionType : ActionType.getPersonActionTypes()) {
-      ActionDto action = actions.stream()
+      Optional<ActionDto> actionOfType = actions.stream()
           .filter(a -> a.type().equals(actionType.toString()))
-          .findFirst()
-          .orElseThrow(() -> new AssertionError("Missing action for type: " + actionType));
-
+          .findFirst();
+      assertThat("Missing action for type: " + actionType, actionOfType.isPresent(), is(true));
+      ActionDto action = actionOfType.get();
       assertThat("Unexpected action id.", action.id(), nullValue());
       assertThat("Unexpected action type.", action.type(), is(actionType.toString()));
       assertThat("Unexpected trainee id.", action.traineeId(), is(TRAINEE_ID));

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/EventPublishingServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/EventPublishingServiceTest.java
@@ -231,7 +231,7 @@ class EventPublishingServiceTest {
     Action action = new Action(ACTION_ID, REVIEW_DATA, TRAINEE_ID, tisReference, PAST, FUTURE,
         COMPLETED);
     ActionBroadcastDto actionBroadcastDto = new ActionBroadcastDto(ACTION_ID.toString(),
-        null, null, null, null, null,
+        REVIEW_DATA.toString(), null, null, null, null,
         null, ActionStatus.DELETED, Instant.now());
 
     when(actionMapper.toDeletedActionBroadcastDto(action)).thenReturn(actionBroadcastDto);
@@ -245,7 +245,7 @@ class EventPublishingServiceTest {
     SnsNotification<ActionBroadcastDto> message = messageCaptor.getValue();
     ActionBroadcastDto payload = message.getPayload();
     assertThat("Unexpected action id.", payload.id(), is(ACTION_ID_STRING));
-    assertThat("Unexpected action type.", payload.type(), nullValue());
+    assertThat("Unexpected action type.", payload.type(), is(REVIEW_DATA.toString()));
     assertThat("Unexpected trainee id.", payload.traineeId(), nullValue());
     assertThat("Unexpected reference info", payload.tisReferenceInfo(), nullValue());
     assertThat("Unexpected available from date.", payload.availableFrom(), nullValue());

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/EventPublishingServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/EventPublishingServiceTest.java
@@ -88,7 +88,9 @@ class EventPublishingServiceTest {
   }
 
   @Test
-  void shouldSetGroupIdWhenPublishingActionUpdateEvent() {
+  void shouldSetGroupIdWhenPublishingActionUpdateEventIfFifo() {
+    URI fifoQueue = URI.create(ACTION_TOPIC_ARN + ".fifo");
+    service = new EventPublishingService(snsTemplate, actionMapper, fifoQueue);
     Action.TisReferenceInfo tisReference = new Action.TisReferenceInfo(TIS_ID, PLACEMENT);
     Action action = new Action(ACTION_ID, REVIEW_DATA, TRAINEE_ID, tisReference, PAST, FUTURE,
         COMPLETED);
@@ -106,6 +108,27 @@ class EventPublishingServiceTest {
 
     SnsNotification<ActionBroadcastDto> message = messageCaptor.getValue();
     assertThat("Unexpected group ID.", message.getGroupId(), is(ACTION_ID_STRING));
+  }
+
+  @Test
+  void shouldNotSetGroupIdWhenPublishingActionUpdateEventIfNotFifo() {
+    Action.TisReferenceInfo tisReference = new Action.TisReferenceInfo(TIS_ID, PLACEMENT);
+    Action action = new Action(ACTION_ID, REVIEW_DATA, TRAINEE_ID, tisReference, PAST, FUTURE,
+        COMPLETED);
+    ActionBroadcastDto actionBroadcastDto = new ActionBroadcastDto(ACTION_ID.toString(),
+        REVIEW_DATA.toString(), TRAINEE_ID, tisReference, PAST, FUTURE,
+        COMPLETED, ActionStatus.CURRENT, Instant.now());
+
+    when(actionMapper.toCurrentActionBroadcastDto(action)).thenReturn(actionBroadcastDto);
+
+    service.publishActionUpdateEvent(action);
+
+    ArgumentCaptor<SnsNotification<ActionBroadcastDto>> messageCaptor = ArgumentCaptor.forClass(
+        SnsNotification.class);
+    verify(snsTemplate).sendNotification(any(), messageCaptor.capture());
+
+    SnsNotification<ActionBroadcastDto> message = messageCaptor.getValue();
+    assertThat("Unexpected group ID.", message.getGroupId(), nullValue());
   }
 
   @Test
@@ -159,7 +182,9 @@ class EventPublishingServiceTest {
   }
 
   @Test
-  void shouldSetGroupIdWhenPublishingActionDeleteEvent() {
+  void shouldSetGroupIdWhenPublishingActionDeleteEventIfFifo() {
+    URI fifoQueue = URI.create(ACTION_TOPIC_ARN + ".fifo");
+    service = new EventPublishingService(snsTemplate, actionMapper, fifoQueue);
     Action.TisReferenceInfo tisReference = new Action.TisReferenceInfo(TIS_ID, PLACEMENT);
     Action action = new Action(ACTION_ID, REVIEW_DATA, TRAINEE_ID, tisReference, PAST, FUTURE,
         COMPLETED);
@@ -177,6 +202,27 @@ class EventPublishingServiceTest {
 
     SnsNotification<ActionBroadcastDto> message = messageCaptor.getValue();
     assertThat("Unexpected group ID.", message.getGroupId(), is(ACTION_ID_STRING));
+  }
+
+  @Test
+  void shouldNotSetGroupIdWhenPublishingActionDeleteEventIfNotFifo() {
+    Action.TisReferenceInfo tisReference = new Action.TisReferenceInfo(TIS_ID, PLACEMENT);
+    Action action = new Action(ACTION_ID, REVIEW_DATA, TRAINEE_ID, tisReference, PAST, FUTURE,
+        COMPLETED);
+    ActionBroadcastDto actionBroadcastDto = new ActionBroadcastDto(ACTION_ID.toString(),
+        null, null, null, null, null,
+        null, ActionStatus.DELETED, Instant.now());
+
+    when(actionMapper.toDeletedActionBroadcastDto(action)).thenReturn(actionBroadcastDto);
+
+    service.publishActionDeleteEvent(action);
+
+    ArgumentCaptor<SnsNotification<ActionBroadcastDto>> messageCaptor = ArgumentCaptor.forClass(
+        SnsNotification.class);
+    verify(snsTemplate).sendNotification(any(), messageCaptor.capture());
+
+    SnsNotification<ActionBroadcastDto> message = messageCaptor.getValue();
+    assertThat("Unexpected group ID.", message.getGroupId(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
**What this does:**
Sets up new incomplete programme membership sign-COJ, complete formR-A, formR-B actions when a programme membership is synced
Deletes these if the programme membership is deleted
Prevent these being completed via the API endpoint
Adds a listener to add registered-on-TSS completed actions

**What this does not do:**
Include any functionality to complete the new events (new listeners)
Add a get-actions endpoint with trainee id (& programme id) parameters (instead of relying on authorization token) for the notifications service to use.
Include any functionality to remove register-on-tss actions (e.g. if the trainee is deregistered?)

Dependencies:
TODO: TIS-OPS to set up new subscriber queue and add permission to service to listen to it.

TIS21-6519