### PR TITLE
feat: API endpoint to retrieve trainee programme actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.13.0"
+version = "0.14.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
@@ -117,8 +117,8 @@ public class ActionResource {
    * @param traineeId   The trainee TIS ID.
    * @param programmeId The programme membership ID.
    * @return A list of all actions associated with the trainee and programme membership, which may
-   * be empty if the programme membership or trainee were not found, but otherwise should contain an
-   * ActionDto for each programmeActionTypes and personActionTypes ActionType.
+   *         be empty if the programme membership or trainee were not found, but otherwise should
+   *         contain an ActionDto for each programmeActionTypes and personActionTypes ActionType.
    */
   @GetMapping("/{traineeId}/{programmeId}")
   public ResponseEntity<List<ActionDto>> getTraineeProgrammeActions(

--- a/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
@@ -52,10 +52,10 @@ public class ActionResource {
   }
 
   /**
-   * Get actions associated with the authenticated trainee.
+   * Get incomplete actions associated with the authenticated trainee.
    *
    * @param token The authentication token containing the trainee ID.
-   * @return A list of actions associated with the trainee, may be empty.
+   * @return A list of incomplete actions associated with the trainee, may be empty.
    */
   @GetMapping
   public ResponseEntity<List<ActionDto>> getTraineeActions(
@@ -76,7 +76,7 @@ public class ActionResource {
     }
 
     List<ActionDto> actions = service.findIncompleteTraineeActions(traineeId);
-    log.info("{} actions found for trainee {}.", actions.size(), traineeId);
+    log.info("{} incomplete actions found for trainee {}.", actions.size(), traineeId);
 
     return ResponseEntity.ok(actions);
   }
@@ -108,5 +108,29 @@ public class ActionResource {
 
     Optional<ActionDto> action = service.completeAsUser(traineeId, actionId);
     return ResponseEntity.of(action);
+  }
+
+  /**
+   * Get complete and incomplete actions associated with a trainee and programme membership. This is
+   * an internal API without an authorization token.
+   *
+   * @param traineeId   The trainee TIS ID.
+   * @param programmeId The programme membership ID.
+   * @return A list of all actions associated with the trainee and programme membership, which may
+   * be empty if the programme membership or trainee were not found, but otherwise should contain an
+   * ActionDto for each programmeActionTypes and personActionTypes ActionType.
+   */
+  @GetMapping("/{traineeId}/{programmeId}")
+  public ResponseEntity<List<ActionDto>> getTraineeProgrammeActions(
+      @PathVariable String traineeId,
+      @PathVariable String programmeId) {
+    log.info("Received request to get actions for trainee {} programme membership {}.",
+        traineeId, programmeId);
+
+    List<ActionDto> actions = service.findTraineeProgrammeMembershipActions(traineeId, programmeId);
+    log.info("{} actions found for trainee {} programme membership {}.", actions.size(),
+        traineeId, programmeId);
+
+    return ResponseEntity.ok(actions);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -367,6 +367,7 @@ public class ActionService {
 
   /**
    * Find all actions associated with a given trainee ID and programme membership ID.
+   *
    * @param traineeId             The ID of the trainee to get actions for.
    * @param programmeMembershipId The ID of the programme membership to get actions for.
    * @return The found actions, empty if no actions found.

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
@@ -362,6 +363,23 @@ public class ActionService {
     List<Action> actions = repository.findAllByTraineeIdAndCompletedIsNullOrderByDueByAsc(
         traineeId);
     return mapper.toDtos(actions);
+  }
+
+  /**
+   * Find all actions associated with a given trainee ID and programme membership ID.
+   * @param traineeId             The ID of the trainee to get actions for.
+   * @param programmeMembershipId The ID of the programme membership to get actions for.
+   * @return The found actions, empty if no actions found.
+   */
+  public List<ActionDto> findTraineeProgrammeMembershipActions(String traineeId,
+      String programmeMembershipId) {
+    List<Action> programmeActions = repository.findByTraineeIdAndTisReferenceInfo(
+        traineeId, programmeMembershipId, PROGRAMME_MEMBERSHIP.toString());
+    List<Action> traineeActions = repository.findByTraineeIdAndTisReferenceInfo(
+        traineeId, traineeId, PERSON.toString());
+    List<Action> allActions = Stream.concat(programmeActions.stream(), traineeActions.stream())
+        .toList();
+    return mapper.toDtos(allActions);
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/actions/api/ActionResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/api/ActionResourceTest.java
@@ -167,4 +167,27 @@ class ActionResourceTest {
     ActionDto action = response.getBody();
     assertThat("Unexpected action.", action, sameInstance(dto));
   }
+
+  @Test
+  void shouldReturnActionsWhenGetTraineeProgrammeActions() {
+    String traineeId = "traineeId";
+    String programmeId = "programmeId";
+
+    ActionDto dto1 = new ActionDto("1", null, null, null, null, null, null);
+    ActionDto dto2 = new ActionDto("2", null, null, null, null, null, null);
+    when(service.findTraineeProgrammeMembershipActions(traineeId, programmeId))
+        .thenReturn(List.of(dto1, dto2));
+
+    ResponseEntity<List<ActionDto>> response = controller.getTraineeProgrammeActions(
+        traineeId, programmeId);
+
+    assertThat("Unexpected status code.", response.getStatusCode(), is(HttpStatus.OK));
+    assertThat("Unexpected response body presence.", response.hasBody(), is(true));
+
+    List<ActionDto> actions = response.getBody();
+    assertThat("Unexpected actions.", actions, notNullValue());
+    assertThat("Unexpected action count.", actions.size(), is(2));
+    assertThat("Unexpected action.", actions.get(0), sameInstance(dto1));
+    assertThat("Unexpected action.", actions.get(1), sameInstance(dto2));
+  }
 }


### PR DESCRIPTION
Generally intended for the notifications service. Slightly 'odd' because it retrieves actions for the programme membership as well as the trainee (to support the TSI21-7466 reminders in a single API call)

TIS21-7503