### PR TITLE
fix: set ENVIRONMENT correctly

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -80,7 +80,7 @@
           "value": "eu-west-2"
         },
         {
-          "name": "SENTRY_ENVIRONMENT",
+          "name": "ENVIRONMENT",
           "value": "${environment}"
         }
       ]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.14.0"
+version = "0.14.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
The `ENVIRONMENT` env var is expected for setting the environment used for X-Ray and Sentry.
Update the AWS task definition to correctly set `ENVIRONMENT` instead of `SENTRY_ENVIRONMENT`.

NO-TICKET