### PR TITLE
fix: only return available actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.14.2"
+version = "0.14.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/api/ActionResource.java
@@ -52,10 +52,10 @@ public class ActionResource {
   }
 
   /**
-   * Get incomplete actions associated with the authenticated trainee.
+   * Get available incomplete actions associated with the authenticated trainee.
    *
    * @param token The authentication token containing the trainee ID.
-   * @return A list of incomplete actions associated with the trainee, may be empty.
+   * @return A list of available incomplete actions associated with the trainee, may be empty.
    */
   @GetMapping
   public ResponseEntity<List<ActionDto>> getTraineeActions(

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -354,14 +354,16 @@ public class ActionService {
   }
 
   /**
-   * Find all incomplete actions associated with a given trainee ID.
+   * Find all available incomplete actions associated with a given trainee ID.
    *
    * @param traineeId The ID of the trainee to get actions for.
    * @return The found actions, empty if no actions found.
    */
   public List<ActionDto> findIncompleteTraineeActions(String traineeId) {
     List<Action> actions = repository.findAllByTraineeIdAndCompletedIsNullOrderByDueByAsc(
-        traineeId);
+        traineeId).stream()
+        .filter(a -> a.availableFrom() == null || !a.availableFrom().isAfter(LocalDate.now()))
+        .toList();
     return mapper.toDtos(actions);
   }
 


### PR DESCRIPTION
To avoid having placement actions due many years hence that are only available from 12-weeks before they start.

cf. @john12321 

NO-TICKET