### PR TITLE
fix: ignore placements with null type

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.14.3"
+version = "0.14.4"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -118,7 +118,8 @@ public class ActionService {
     List<Action> actions = new ArrayList<>();
 
     if (Objects.equals(operation, Operation.LOAD)) {
-      if (PLACEMENT_TYPES_TO_ACT_ON.stream().anyMatch(dto.placementType()::equalsIgnoreCase)) {
+      if (dto.placementType() != null
+          && PLACEMENT_TYPES_TO_ACT_ON.stream().anyMatch(dto.placementType()::equalsIgnoreCase)) {
 
         addOrUpdatePlacementAction(dto, actions);
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -764,9 +764,12 @@ class ActionServiceTest {
     verify(repository, never()).insert(anyList());
   }
 
-  @Test
-  void shouldNotInsertActionAndDeleteAnyExistingNotCompleteActionsWhenPlacementTypeIgnored() {
-    PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, POST_EPOCH, "ignored placement type");
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = "ignored placement type")
+  void shouldNotInsertActionAndDeleteAnyExistingNotCompleteActionsWhenPlacementTypeIgnored(
+      String placementType) {
+    PlacementDto dto = new PlacementDto(TIS_ID, TRAINEE_ID, POST_EPOCH, placementType);
 
     when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionType(eq(TRAINEE_ID),
         eq(TIS_ID), eq(String.valueOf(PLACEMENT)), any())).thenReturn(Collections.emptyList());


### PR DESCRIPTION
Cut down on Sentry noise for unprocessable placement entries (e.g 78855 has placementType null)

NO-TICKET