### PR TITLE
chore: updated new prod encrypted db ssm param

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -34,19 +34,19 @@
         },
         {
           "name": "MONGO_HOST",
-          "valueFrom": "/tis/trainee/${environment}/db/host"
+          "valueFrom": "/tis/selfservice/${environment}/db/host"
         },
         {
           "name": "MONGO_PORT",
-          "valueFrom": "/tis/trainee/${environment}/db/port"
+          "valueFrom": "/tis/selfservice/${environment}/db/port"
         },
         {
           "name": "MONGO_USER",
-          "valueFrom": "/tis/trainee/${environment}/db/username"
+          "valueFrom": "/tis/selfservice/${environment}/db/username"
         },
         {
           "name": "MONGO_PASSWORD",
-          "valueFrom": "/tis/trainee/${environment}/db/password"
+          "valueFrom": "/tis/selfservice/${environment}/db/password"
         },
         {
           "name": "SENTRY_DSN",


### PR DESCRIPTION
I see the naming convention inconsistency too, but we can't override the existing resource names since they're integrated with the current DB creation flow. If this becomes a concern, we can update the name prefix for the new encrypted DB resources after we complete the migration and remove the old db infrastructure.
