### PR TITLE
fix: foundation programme actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.15.5"
+version = "0.15.6"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
@@ -176,6 +176,68 @@ class ProgrammeMembershipListenerIntegrationTest {
   }
 
   @Test
+  void shouldInsertAllFoundationActionsWhenFoundationProgrammeMembershipCreated()
+      throws JsonProcessingException {
+    String traineeId = UUID.randomUUID().toString();
+    String eventString = """
+        {
+          "record": {
+            "data": {
+              "tisId": "%s",
+              "personId": "%s",
+              "startDate": "%s",
+              "curricula" : [
+                {
+                  "curriculumSpecialty": "Foundation",
+                  "curriculumSubType": "AFT"
+                }
+              ]
+            },
+            "operation": "%s"
+          }
+        }""".formatted(PROGRAMME_MEMBERSHIP_ID, traineeId, START_DATE, LOAD);
+
+    JsonNode eventJson = JsonMapper.builder()
+        .build()
+        .readTree(eventString);
+
+    sqsTemplate.send(PROGRAMME_MEMBERSHIP_SYNCED_QUEUE, eventJson);
+
+    Criteria criteria = Criteria.where("traineeId").is(traineeId);
+    Query query = Query.query(criteria);
+    List<Action> actions = new ArrayList<>();
+
+    await()
+        .pollInterval(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(() -> {
+          List<Action> found = mongoTemplate.find(query, Action.class);
+          assertThat("Unexpected action count.", found.size(),
+              is(ActionType.getFoundationProgrammeActionTypes().size()));
+          actions.addAll(found);
+        });
+
+    for (ActionType actionType : ActionType.getFoundationProgrammeActionTypes()) {
+      Optional<Action> actionOptional = actions.stream()
+          .filter(a -> a.type().equals(actionType))
+          .findFirst();
+      assertThat("Missing action for type: " + actionType, actionOptional.isPresent(), is(true));
+      Action action = actionOptional.get();
+      assertThat("Unexpected action id.", action.id(), notNullValue());
+      assertThat("Unexpected action type.", action.type(), is(actionType));
+      assertThat("Unexpected trainee id.", action.traineeId(), is(traineeId));
+      assertThat("Unexpected available from date.", action.availableFrom(), is(NOW));
+      assertThat("Unexpected due by date.", action.dueBy(), is(START_DATE));
+      assertThat("Unexpected completed date.", action.completed(), nullValue());
+
+      TisReferenceInfo tisReference = action.tisReferenceInfo();
+      assertThat("Unexpected TIS id.", tisReference.id(), is(PROGRAMME_MEMBERSHIP_ID));
+      assertThat("Unexpected TIS type.", tisReference.type(), is(PROGRAMME_MEMBERSHIP));
+    }
+  }
+
+  @Test
   void shouldInsertCompletedSignCojActionWhenProgrammeMembershipHasCoj()
       throws JsonProcessingException {
     String traineeId = UUID.randomUUID().toString();

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDto.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.LocalDate;
+import java.util.List;
 import uk.nhs.tis.trainee.actions.dto.helpers.ConditionsOfJoiningDeserializer;
 
 /**
@@ -37,11 +38,49 @@ import uk.nhs.tis.trainee.actions.dto.helpers.ConditionsOfJoiningDeserializer;
  * @param traineeId           The trainee ID associated with the membership.
  * @param startDate           The programme start date.
  * @param conditionsOfJoining The serialized conditions of joining for the programme membership.
+ * @param curricula           The list of curricula associated with the programme membership.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ProgrammeMembershipDto(@JsonAlias({"tisId", "uuid"}) String id,
-                                     @JsonAlias("personId") String traineeId, LocalDate startDate,
-                                     @JsonDeserialize(using = ConditionsOfJoiningDeserializer.class)
-                                     ConditionsOfJoining conditionsOfJoining) {
+public record ProgrammeMembershipDto(
+    @JsonAlias({"tisId", "uuid"})
+    String id,
 
+    @JsonAlias("personId")
+    String traineeId, LocalDate startDate,
+
+    @JsonDeserialize(using = ConditionsOfJoiningDeserializer.class)
+    ConditionsOfJoining conditionsOfJoining,
+
+    List<CurriculumDto> curricula
+
+) {
+
+  /**
+   * A representation of a curriculum associated with a programme membership.
+   *
+   * @param curriculumSpecialty The curriculum specialty.
+   * @param curriculumSubType   The curriculum subtype.
+   */
+  public record CurriculumDto(String curriculumSpecialty, String curriculumSubType) {
+
+  }
+
+  /**
+   * Identify if a programme membership is a foundation programme, by checking if any of the
+   * curricula have a specialty or subtype indicating it's a foundation programme.
+   *
+   * @return true if the programme membership is a foundation programme, otherwise false.
+   */
+  public boolean isFoundationProgramme() {
+    if (curricula() == null) {
+      return false;
+    }
+    return curricula().stream()
+        .anyMatch(curriculum -> {
+          String specialty = curriculum.curriculumSpecialty();
+          String subtype = curriculum.curriculumSubType();
+          return (subtype != null && (subtype.equalsIgnoreCase("AFT"))
+              || (specialty != null && specialty.equalsIgnoreCase("FOUNDATION")));
+        });
+  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/model/ActionType.java
@@ -46,6 +46,13 @@ public enum ActionType {
       SIGN_FORM_R_PART_B);
 
   /**
+   * The set of Programme action types.
+   */
+  @Getter
+  private static final Set<ActionType> foundationProgrammeActionTypes = EnumSet.of(
+      REVIEW_DATA);
+
+  /**
    * The set of Placement action types.
    */
   @Getter

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
@@ -165,7 +166,12 @@ public class ActionService {
 
     if (Objects.equals(operation, Operation.LOAD)
         && !(dto.startDate().isBefore(ACTIONS_EPOCH))) {
-      for (ActionType actionType : ActionType.getProgrammeActionTypes()) {
+
+      Set<ActionType> actionTypes =
+          dto.isFoundationProgramme() ? ActionType.getFoundationProgrammeActionTypes()
+              : ActionType.getProgrammeActionTypes();
+
+      for (ActionType actionType : actionTypes) {
         Action newAction = mapper.toAction(dto, actionType);
         if (existingActions.stream().noneMatch(a -> a.type().equals(actionType))) {
           // only add action if it does not already exist
@@ -364,7 +370,7 @@ public class ActionService {
    */
   public List<ActionDto> findIncompleteTraineeActions(String traineeId) {
     List<Action> actions = repository.findAllByTraineeIdAndCompletedIsNullOrderByDueByAsc(
-        traineeId).stream()
+            traineeId).stream()
         .filter(a -> a.availableFrom() == null || !a.availableFrom().isAfter(LocalDate.now()))
         .toList();
     return mapper.toDtos(actions);
@@ -506,8 +512,8 @@ public class ActionService {
   }
 
   /**
-   * Move all actions from one trainee to another. Assumes that fromTraineeId and toTraineeId
-   * are valid. The updated actions are broadcast as events.
+   * Move all actions from one trainee to another. Assumes that fromTraineeId and toTraineeId are
+   * valid. The updated actions are broadcast as events.
    *
    * @param fromTraineeId The trainee ID to move actions from.
    * @param toTraineeId   The trainee ID to move actions to.

--- a/src/test/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDtoTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDtoTest.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.actions.dto;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto.CurriculumDto;
+
+class ProgrammeMembershipDtoTest {
+
+  private static final String PM_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final LocalDate START_DATE = LocalDate.now().minusYears(1);
+  private static final ConditionsOfJoining CONDITIONS_OF_JOINING = new ConditionsOfJoining(
+      Instant.now(), "10", Instant.now());
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldNotBeFoundationWhenNoCurricula(List<CurriculumDto> curricula) {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, curricula);
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(false));
+  }
+
+  @Test
+  void shouldBeFoundationWhenSpecialtyNullAndSubTypeNull() {
+    CurriculumDto curriculum = new CurriculumDto(null, null);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, List.of(curriculum));
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(false));
+  }
+
+  @ParameterizedTest
+  @EmptySource
+  @ValueSource(strings = "NotAFT")
+  void shouldNotBeFoundationWhenSubTypeNotAft(String subType) {
+    CurriculumDto curriculum = new CurriculumDto(null, subType);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, List.of(curriculum));
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"AFT", "aft", "Aft"})
+  void shouldBeFoundationWhenSubTypeAft(String subType) {
+    CurriculumDto curriculum = new CurriculumDto(null, subType);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, List.of(curriculum));
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(true));
+  }
+
+  @ParameterizedTest
+  @EmptySource
+  @ValueSource(strings = "Not Foundation")
+  void shouldNotBeFoundationWhenSpecialtyNotFoundation(String specialty) {
+    CurriculumDto curriculum = new CurriculumDto(specialty, null);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, List.of(curriculum));
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"FOUNDATION", "foundation", "Foundation"})
+  void shouldBeFoundationWhenSpecialtyFoundation(String specialty) {
+    CurriculumDto curriculum = new CurriculumDto(specialty, null);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, List.of(curriculum));
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(true));
+  }
+
+  @Test
+  void shouldBeFoundationWhenAnyCurriculumIsFoundation() {
+    List<CurriculumDto> curricula = List.of(
+        new CurriculumDto(null, null),
+        new CurriculumDto("No Foundation", "Not Aft"),
+        new CurriculumDto(null, "AFT"),
+        new CurriculumDto("FOUNDATION", null)
+    );
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
+        CONDITIONS_OF_JOINING, curricula);
+
+    assertThat("Unexpected foundation status.", dto.isFoundationProgramme(), is(true));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDtoTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDtoTest.java
@@ -53,7 +53,7 @@ class ProgrammeMembershipDtoTest {
   }
 
   @Test
-  void shouldBeFoundationWhenSpecialtyNullAndSubTypeNull() {
+  void shouldNotBeFoundationWhenSpecialtyNullAndSubTypeNull() {
     CurriculumDto curriculum = new CurriculumDto(null, null);
     ProgrammeMembershipDto dto = new ProgrammeMembershipDto(PM_ID, TRAINEE_ID, START_DATE,
         CONDITIONS_OF_JOINING, List.of(curriculum));

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.bson.types.ObjectId;
@@ -75,6 +76,7 @@ import uk.nhs.tis.trainee.actions.dto.ConditionsOfJoining;
 import uk.nhs.tis.trainee.actions.dto.FormUpdateEvent;
 import uk.nhs.tis.trainee.actions.dto.PlacementDto;
 import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto.CurriculumDto;
 import uk.nhs.tis.trainee.actions.dto.enumeration.FormLifecycleState;
 import uk.nhs.tis.trainee.actions.event.Operation;
 import uk.nhs.tis.trainee.actions.mapper.ActionMapperImpl;
@@ -112,10 +114,11 @@ class ActionServiceTest {
     service = new ActionService(repository, new ActionMapperImpl(), eventPublishingService);
   }
 
-  @Test
-  void shouldInsertAllActionsOnFirstSightOfPostEpochProgrammeMembership() {
-    ProgrammeMembershipDto dto
-        = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, ACTIONS_EPOCH, null);
+  @ParameterizedTest
+  @ValueSource(strings = {"Foundation", "Not Foundation"})
+  void shouldInsertAllActionsOnFirstSightOfPostEpochProgrammeMembership(String specialty) {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, ACTIONS_EPOCH, null,
+        List.of(new CurriculumDto(specialty, null)));
 
     when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
         .thenReturn(new ArrayList<>());
@@ -123,7 +126,10 @@ class ActionServiceTest {
 
     List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
 
-    int expectedActionCount = ActionType.getProgrammeActionTypes().size();
+    Set<ActionType> actionTypes =
+        specialty.equals("Foundation") ? ActionType.getFoundationProgrammeActionTypes()
+            : ActionType.getProgrammeActionTypes();
+    int expectedActionCount = actionTypes.size();
     assertThat("Unexpected action count.", actions.size(), is(expectedActionCount));
 
     // should broadcast inserted action
@@ -132,7 +138,7 @@ class ActionServiceTest {
         .publishActionUpdateEvent(actionCaptor.capture());
     List<Action> actionsPublished = actionCaptor.getAllValues();
 
-    for (ActionType actionType : ActionType.getProgrammeActionTypes()) {
+    for (ActionType actionType : actionTypes) {
       Optional<ActionDto> actionOfType = actions.stream()
           .filter(a -> a.type().equals(actionType.toString()))
           .findFirst();
@@ -169,9 +175,11 @@ class ActionServiceTest {
     }
   }
 
-  @Test
-  void shouldNotInsertActionsOnFirstSightOfPreEpochProgrammeMembership() {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, PRE_EPOCH, null);
+  @ParameterizedTest
+  @ValueSource(strings = {"Foundation", "Not Foundation"})
+  void shouldNotInsertActionsOnFirstSightOfPreEpochProgrammeMembership(String specialty) {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, PRE_EPOCH, null,
+        List.of(new CurriculumDto(specialty, null)));
 
     List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
 
@@ -181,9 +189,11 @@ class ActionServiceTest {
     verifyNoInteractions(eventPublishingService);
   }
 
-  @Test
-  void shouldNotInsertActionsOnAlreadyActionedPostEpochProgrammeMembership() {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null);
+  @ParameterizedTest
+  @ValueSource(strings = {"Foundation", "Not Foundation"})
+  void shouldNotInsertActionsOnAlreadyActionedPostEpochProgrammeMembership(String specialty) {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto(specialty, null)));
 
     TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
     List<Action> existingActions = new ArrayList<>();
@@ -206,7 +216,8 @@ class ActionServiceTest {
   @Test
   void shouldInsertCompletedCojSignedActionOnProgrammeMembershipWithCoj() {
     ConditionsOfJoining coj = new ConditionsOfJoining(Instant.MIN, "version", Instant.MAX);
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, ACTIONS_EPOCH, coj);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, ACTIONS_EPOCH, coj,
+        null);
     when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
         .thenReturn(new ArrayList<>());
 
@@ -233,7 +244,8 @@ class ActionServiceTest {
   @Test
   void shouldCompleteCojSignedActionOnProgrammeMembershipWithExistingCojAction() {
     ConditionsOfJoining coj = new ConditionsOfJoining(Instant.MIN, "version", Instant.MAX);
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, PRE_EPOCH, coj);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, PRE_EPOCH, coj,
+        null);
 
     TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
     List<Action> existingActions = List.of(new Action(ObjectId.get(), SIGN_COJ, TRAINEE_ID,
@@ -806,7 +818,8 @@ class ActionServiceTest {
   @MethodSource("providePreAndPostEpochDates")
   void shouldDeleteAnyExistingNotCompleteActionsWhenProgrammeMembershipOperationIsDelete(
       LocalDate theDate) {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, theDate, null);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, theDate, null,
+        null);
 
     Action action1 = new Action(ObjectId.get(), REVIEW_DATA, TRAINEE_ID, null, null,
         POST_EPOCH, null);


### PR DESCRIPTION
Foundation doctors should not have actions generated for Form-R or Conditions of Joining.

Update ProgrammeMembershipDto to capture curricula details and determine whether the PM is for a foundation programme or not. Update ActionsService to select the required action types based on whether the programme is foundation or not.

TIS21-8528
TIS21-8529