### PR TITLE
fix: deserialize curricula from string

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.15.6"
+version = "0.15.7"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/FormListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/FormListenerIntegrationTest.java
@@ -61,7 +61,7 @@ import uk.nhs.tis.trainee.actions.model.ActionType;
 
 @SpringBootTest
 @Testcontainers
-public class FormListenerIntegrationTest {
+class FormListenerIntegrationTest {
 
   private static final String TRAINEE_ID = UUID.randomUUID().toString();
   private static final String PROGRAMME_MEMBERSHIP_ID = UUID.randomUUID().toString();

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
@@ -186,12 +186,7 @@ class ProgrammeMembershipListenerIntegrationTest {
               "tisId": "%s",
               "personId": "%s",
               "startDate": "%s",
-              "curricula" : [
-                {
-                  "curriculumSpecialty": "Foundation",
-                  "curriculumSubType": "AFT"
-                }
-              ]
+              "curricula": "[{\\"curriculumSubType\\":\\"AFT\\",\\"curriculumSpecialty\\":\\"Foundation\\"}]"
             },
             "operation": "%s"
           }

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/ProgrammeMembershipDto.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.LocalDate;
 import java.util.List;
 import uk.nhs.tis.trainee.actions.dto.helpers.ConditionsOfJoiningDeserializer;
+import uk.nhs.tis.trainee.actions.dto.helpers.CurriculaDeserializer;
 
 /**
  * A representation of a programme membership.
@@ -51,6 +52,7 @@ public record ProgrammeMembershipDto(
     @JsonDeserialize(using = ConditionsOfJoiningDeserializer.class)
     ConditionsOfJoining conditionsOfJoining,
 
+    @JsonDeserialize(using = CurriculaDeserializer.class)
     List<CurriculumDto> curricula
 
 ) {

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializer.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializer.java
@@ -30,32 +30,33 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
-import uk.nhs.tis.trainee.actions.dto.ConditionsOfJoining;
+import java.util.List;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto.CurriculumDto;
 
 /**
- * A deserializer for ConditionsOfJoining.
+ * A deserializer for CurriculumDto.
  *
- * <p>This deserializes a JSON string into a ConditionsOfJoining object using Jackson.</p>
+ * <p>This deserializes a JSON string into a List of CurriculumDto object using Jackson.</p>
  */
-public class ConditionsOfJoiningDeserializer extends JsonDeserializer<ConditionsOfJoining> {
+public class CurriculaDeserializer extends JsonDeserializer<List<CurriculumDto>> {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
       .registerModule(new JavaTimeModule())
       .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
   /**
-   * Deserialize a JSON string into a ConditionsOfJoining object. Note that a serialized value of
-   * "null" will be converted into a null object.
+   * Deserialize a JSON string into a CurriculumDto List. Note that a serialized value of "null"
+   * will be converted into a null object.
    *
    * @param p    The JsonParser to read the JSON string.
    * @param ctxt The DeserializationContext.
-   * @return The deserialized ConditionsOfJoining object.
+   * @return The deserialized CurriculumDto List.
    * @throws IOException If an error occurs during deserialization.
    */
   @Override
-  public ConditionsOfJoining deserialize(JsonParser p, DeserializationContext ctxt)
+  public List<CurriculumDto> deserialize(JsonParser p, DeserializationContext ctxt)
       throws IOException {
-    String cojString = p.getValueAsString();
-    return OBJECT_MAPPER.readValue(cojString, new TypeReference<>() {});
+    String curriculaString = p.getValueAsString();
+    return OBJECT_MAPPER.readValue(curriculaString, new TypeReference<>() {});
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializerTest.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package uk.nhs.tis.trainee.actions.dto.helpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.tis.trainee.actions.dto.ProgrammeMembershipDto.CurriculumDto;
+
+@ExtendWith(MockitoExtension.class)
+class CurriculaDeserializerTest {
+
+  private CurriculaDeserializer deserializer;
+
+  @Mock
+  private JsonParser parser;
+
+  @Mock
+  private DeserializationContext context;
+
+  @BeforeEach
+  void setUp() {
+    deserializer = new CurriculaDeserializer();
+  }
+
+  @Test
+  void shouldDeserializeValidJson() throws IOException {
+    String validJson = """
+        [
+          {
+            "curriculumSubType": "subType1",
+            "curriculumSpecialty": "specialty1"
+          },
+          {
+            "curriculumSubType": "subType2",
+            "curriculumSpecialty": "specialty2"
+          }
+        ]
+        """;
+    when(parser.getValueAsString()).thenReturn(validJson);
+
+    List<CurriculumDto> result = deserializer.deserialize(parser, context);
+
+    assertThat("Unexpected curriculum count.", result, hasSize(2));
+
+    CurriculumDto curriculum1 = result.get(0);
+    assertThat("Unexpected curriculum sub type.", curriculum1.curriculumSubType(), is("subType1"));
+    assertThat("Unexpected curriculum specialty.", curriculum1.curriculumSpecialty(),
+        is("specialty1"));
+
+    CurriculumDto curriculum2 = result.get(1);
+    assertThat("Unexpected curriculum sub type.", curriculum2.curriculumSubType(), is("subType2"));
+    assertThat("Unexpected curriculum specialty.", curriculum2.curriculumSpecialty(),
+        is("specialty2"));
+  }
+
+  @Test
+  void shouldReturnNullWhenJsonIsNull() throws IOException {
+    when(parser.getValueAsString()).thenReturn("null");
+
+    List<CurriculumDto> result = deserializer.deserialize(parser, context);
+
+    assertThat("Unexpected result.", result, nullValue());
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidJson() throws IOException {
+    String invalidJson = "invalid json";
+    when(parser.getValueAsString()).thenReturn(invalidJson);
+
+    assertThrows(IOException.class, () -> deserializer.deserialize(parser, context));
+  }
+
+  @Test
+  void shouldDeserializeEmptyList() throws IOException {
+    String emptyJson = "[]";
+    when(parser.getValueAsString()).thenReturn(emptyJson);
+
+    List<CurriculumDto> result = deserializer.deserialize(parser, context);
+
+    assertThat("Unexpected curriculum count.", result, hasSize(0));
+  }
+}


### PR DESCRIPTION
The programme membership's curricula list is received as a string and needs custom deserialization.

TIS21-8528
TIS21-8529