### PR TITLE
Fix/remove unneeded foundation actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.15.7"
+version = "0.15.8"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/repository/ActionRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/repository/ActionRepositoryIntegrationTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
+import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_COJ;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 
@@ -159,5 +160,57 @@ class ActionRepositoryIntegrationTest {
     List<Action> deletedActions = repository.deleteByTraineeIdAndTisReferenceInfo(
         TRAINEE_ID_1, TIS_ID, PLACEMENT.toString());
     assertThat("Unexpected delete count.", deletedActions.size(), is(1));
+  }
+
+  @Test
+  void shouldNotDeleteCompleteActionOfTypeWhenDeletingByActionTypeAndNotComplete() {
+    TisReferenceInfo referenceInfo = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action action = new Action(null, SIGN_COJ, TRAINEE_ID_1, referenceInfo, PAST, FUTURE,
+        Instant.now());
+
+    repository.insert(action);
+
+    List<Action> deletedActions =
+        repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+            TRAINEE_ID_1, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString());
+
+    assertThat("Unexpected delete count.", deletedActions.size(), is(0));
+    assertThat("Unexpected remaining count.", repository.findAll().size(), is(1));
+  }
+
+  @Test
+  void shouldDeleteIncompleteActionOfTypeWhenDeletingByActionTypeAndNotComplete() {
+    TisReferenceInfo referenceInfo = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action action = new Action(null, SIGN_COJ, TRAINEE_ID_1, referenceInfo, PAST, FUTURE, null);
+
+    repository.insert(action);
+
+    List<Action> deletedActions =
+        repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+            TRAINEE_ID_1, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString());
+
+    assertThat("Unexpected delete count.", deletedActions.size(), is(1));
+    assertThat("Unexpected remaining count.", repository.findAll().size(), is(0));
+  }
+
+  @Test
+  void shouldNotDeleteIncompleteActionOfDifferentTypeWhenDeletingByActionTypeAndNotComplete() {
+    TisReferenceInfo referenceInfo = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action actionToDelete = new Action(null, SIGN_COJ, TRAINEE_ID_1, referenceInfo, PAST, FUTURE,
+        null);
+    Action actionToKeep = new Action(null, REVIEW_DATA, TRAINEE_ID_1, referenceInfo, PAST, FUTURE,
+        null);
+
+    repository.insert(actionToDelete);
+    repository.insert(actionToKeep);
+
+    List<Action> deletedActions =
+        repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+            TRAINEE_ID_1, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString());
+
+    assertThat("Unexpected delete count.", deletedActions.size(), is(1));
+    List<Action> remaining = repository.findAll();
+    assertThat("Unexpected remaining count.", remaining.size(), is(1));
+    assertThat("Unexpected remaining action type.", remaining.get(0).type(), is(REVIEW_DATA));
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/repository/ActionRepository.java
@@ -103,6 +103,22 @@ public interface ActionRepository extends MongoRepository<Action, ObjectId> {
       String tisId, String type, String actionType);
 
   /**
+   * Delete specific incomplete TIS entity action(s) for a trainee by action type.
+   *
+   * @param traineeId  The trainee ID.
+   * @param tisId      The TIS ID of the entity.
+   * @param type       The entity type.
+   * @param actionType The action type to delete.
+   */
+  @DeleteQuery(value = "{$and : [{'traineeId': ?0}, "
+      + "{'tisReferenceInfo.id': ?1}, "
+      + "{'tisReferenceInfo.type': ?2}, "
+      + "{'type': ?3}, "
+      + "{'completed': null}]}")
+  List<Action> deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(String traineeId,
+      String tisId, String type, String actionType);
+
+  /**
    * Find specific TIS entity action(s) for a trainee.
    *
    * @param traineeId The trainee ID.

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -268,30 +268,37 @@ public class ActionService {
   /**
    * Delete incomplete programme membership actions that are not valid for foundation programmes.
    *
-   * @param dto             The programme membership being processed.
+   * @param dto The programme membership being processed.
    * @param existingActions The existing actions for the programme membership.
    */
-  private void deleteUnneededFoundationActions(ProgrammeMembershipDto dto,
-      List<Action> existingActions) {
+  private void deleteUnneededFoundationActions(
+      ProgrammeMembershipDto dto, List<Action> existingActions) {
     Set<ActionType> foundationActionTypes = ActionType.getFoundationProgrammeActionTypes();
     // To avoid expensive database calls to delete non-existent actions, we filter the existing
     // actions to find any incomplete actions that are not valid for foundation programmes,
     // and only then delete those actions from the database using their type.
-    List<ActionType> unneededActionTypes = existingActions.stream()
-        .filter(action -> action.completed() == null)
-        .map(Action::type)
-        .filter(actionType -> !foundationActionTypes.contains(actionType))
-        .distinct()
-        .toList();
-    unneededActionTypes.forEach(actionType -> {
-      List<Action> deletedActions =
-          repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-              dto.traineeId(), dto.id(), PROGRAMME_MEMBERSHIP.toString(),
-              actionType.toString());
-      log.info("{} unneeded foundation action(s) deleted for {} {}", deletedActions.size(),
-          PROGRAMME_MEMBERSHIP, dto.id());
-      deletedActions.forEach(eventPublishingService::publishActionDeleteEvent);
-    });
+    List<ActionType> unneededActionTypes =
+        existingActions.stream()
+            .filter(action -> action.completed() == null)
+            .map(Action::type)
+            .filter(actionType -> !foundationActionTypes.contains(actionType))
+            .distinct()
+            .toList();
+    unneededActionTypes.forEach(
+        actionType -> {
+          List<Action> deletedActions =
+              repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+                  dto.traineeId(),
+                  dto.id(),
+                  PROGRAMME_MEMBERSHIP.toString(),
+                  actionType.toString());
+          log.info(
+              "{} unneeded foundation action(s) deleted for {} {}",
+              deletedActions.size(),
+              PROGRAMME_MEMBERSHIP,
+              dto.id());
+          deletedActions.forEach(eventPublishingService::publishActionDeleteEvent);
+        });
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -222,35 +222,6 @@ public class ActionService {
   }
 
   /**
-   * Delete incomplete programme membership actions that are not valid for foundation programmes.
-   *
-   * @param dto             The programme membership being processed.
-   * @param existingActions The existing actions for the programme membership.
-   */
-  private void deleteUnneededFoundationActions(ProgrammeMembershipDto dto,
-      List<Action> existingActions) {
-    Set<ActionType> foundationActionTypes = ActionType.getFoundationProgrammeActionTypes();
-    // To avoid expensive database calls to delete non-existent actions, we filter the existing
-    // actions to find any incomplete actions that are not valid for foundation programmes,
-    // and only then delete those actions from the database using their type.
-    List<ActionType> unneededActionTypes = existingActions.stream()
-        .filter(action -> action.completed() == null)
-        .map(Action::type)
-        .filter(actionType -> !foundationActionTypes.contains(actionType))
-        .distinct()
-        .toList();
-    unneededActionTypes.forEach(actionType -> {
-          List<Action> deletedActions =
-              repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-                  dto.traineeId(), dto.id(), PROGRAMME_MEMBERSHIP.toString(),
-                  actionType.toString());
-          log.info("{} unneeded foundation action(s) deleted for {} {}", deletedActions.size(),
-              PROGRAMME_MEMBERSHIP, dto.id());
-          deletedActions.forEach(eventPublishingService::publishActionDeleteEvent);
-        });
-  }
-
-  /**
    * Updates the actions associated with the given Operation and User account data.
    *
    * @param operation The operation that triggered the update.
@@ -292,6 +263,35 @@ public class ActionService {
     List<Action> actionInserted = repository.insert(actions);
     actionInserted.forEach(eventPublishingService::publishActionUpdateEvent);
     return mapper.toDtos(actionInserted);
+  }
+
+  /**
+   * Delete incomplete programme membership actions that are not valid for foundation programmes.
+   *
+   * @param dto             The programme membership being processed.
+   * @param existingActions The existing actions for the programme membership.
+   */
+  private void deleteUnneededFoundationActions(ProgrammeMembershipDto dto,
+      List<Action> existingActions) {
+    Set<ActionType> foundationActionTypes = ActionType.getFoundationProgrammeActionTypes();
+    // To avoid expensive database calls to delete non-existent actions, we filter the existing
+    // actions to find any incomplete actions that are not valid for foundation programmes,
+    // and only then delete those actions from the database using their type.
+    List<ActionType> unneededActionTypes = existingActions.stream()
+        .filter(action -> action.completed() == null)
+        .map(Action::type)
+        .filter(actionType -> !foundationActionTypes.contains(actionType))
+        .distinct()
+        .toList();
+    unneededActionTypes.forEach(actionType -> {
+      List<Action> deletedActions =
+          repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+              dto.traineeId(), dto.id(), PROGRAMME_MEMBERSHIP.toString(),
+              actionType.toString());
+      log.info("{} unneeded foundation action(s) deleted for {} {}", deletedActions.size(),
+          PROGRAMME_MEMBERSHIP, dto.id());
+      deletedActions.forEach(eventPublishingService::publishActionDeleteEvent);
+    });
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -167,6 +167,10 @@ public class ActionService {
     if (Objects.equals(operation, Operation.LOAD)
         && !(dto.startDate().isBefore(ACTIONS_EPOCH))) {
 
+      if (dto.isFoundationProgramme()) {
+        deleteUnneededFoundationActions(dto);
+      }
+
       Set<ActionType> actionTypes =
           dto.isFoundationProgramme() ? ActionType.getFoundationProgrammeActionTypes()
               : ActionType.getProgrammeActionTypes();
@@ -215,6 +219,26 @@ public class ActionService {
     List<Action> actionInserted = repository.insert(actions);
     actionInserted.forEach(eventPublishingService::publishActionUpdateEvent);
     return mapper.toDtos(actionInserted);
+  }
+
+  /**
+   * Delete incomplete programme membership actions that are not valid for foundation programmes.
+   *
+   * @param dto The programme membership being processed.
+   */
+  private void deleteUnneededFoundationActions(ProgrammeMembershipDto dto) {
+    Set<ActionType> foundationActionTypes = ActionType.getFoundationProgrammeActionTypes();
+    ActionType.getProgrammeActionTypes().stream()
+        .filter(actionType -> !foundationActionTypes.contains(actionType))
+        .forEach(actionType -> {
+          List<Action> deletedActions =
+              repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+                  dto.traineeId(), dto.id(), PROGRAMME_MEMBERSHIP.toString(),
+                  actionType.toString());
+          log.info("{} unneeded foundation action(s) deleted for {} {}", deletedActions.size(),
+              PROGRAMME_MEMBERSHIP, dto.id());
+          deletedActions.forEach(eventPublishingService::publishActionDeleteEvent);
+        });
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -194,7 +194,9 @@ public class ActionService {
 
     // Handle Conditions of Joining (CoJ) action. We ignore ACTIONS_EPOCH and start date here to
     // avoid dangling CoJ actions where a programme start date has been updated to before the epoch.
-    if (Objects.equals(operation, Operation.LOAD) && dto.conditionsOfJoining() != null) {
+    // CoJ is not applicable to foundation programmes, so skip this block for them.
+    if (Objects.equals(operation, Operation.LOAD) && dto.conditionsOfJoining() != null
+        && !dto.isFoundationProgramme()) {
       log.info("Completing any CoJ actions for Programme Membership {}.", dto.id());
       // If a CoJ action has just been created, replace it with a new completed action. This should
       // only be possible if bulk-loading programme memberships that already have signed CoJs.
@@ -293,8 +295,9 @@ public class ActionService {
                   PROGRAMME_MEMBERSHIP.toString(),
                   actionType.toString());
           log.info(
-              "{} unneeded foundation action(s) deleted for {} {}",
+              "{} unneeded foundation action(s) of type {} deleted for {} {}",
               deletedActions.size(),
+              actionType,
               PROGRAMME_MEMBERSHIP,
               dto.id());
           deletedActions.forEach(eventPublishingService::publishActionDeleteEvent);

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -168,7 +168,7 @@ public class ActionService {
         && !(dto.startDate().isBefore(ACTIONS_EPOCH))) {
 
       if (dto.isFoundationProgramme()) {
-        deleteUnneededFoundationActions(dto);
+        deleteUnneededFoundationActions(dto, existingActions);
       }
 
       Set<ActionType> actionTypes =
@@ -224,13 +224,22 @@ public class ActionService {
   /**
    * Delete incomplete programme membership actions that are not valid for foundation programmes.
    *
-   * @param dto The programme membership being processed.
+   * @param dto             The programme membership being processed.
+   * @param existingActions The existing actions for the programme membership.
    */
-  private void deleteUnneededFoundationActions(ProgrammeMembershipDto dto) {
+  private void deleteUnneededFoundationActions(ProgrammeMembershipDto dto,
+      List<Action> existingActions) {
     Set<ActionType> foundationActionTypes = ActionType.getFoundationProgrammeActionTypes();
-    ActionType.getProgrammeActionTypes().stream()
+    // To avoid expensive database calls to delete non-existent actions, we filter the existing
+    // actions to find any incomplete actions that are not valid for foundation programmes,
+    // and only then delete those actions from the database using their type.
+    List<ActionType> unneededActionTypes = existingActions.stream()
+        .filter(action -> action.completed() == null)
+        .map(Action::type)
         .filter(actionType -> !foundationActionTypes.contains(actionType))
-        .forEach(actionType -> {
+        .distinct()
+        .toList();
+    unneededActionTypes.forEach(actionType -> {
           List<Action> deletedActions =
               repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
                   dto.traineeId(), dto.id(), PROGRAMME_MEMBERSHIP.toString(),

--- a/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/service/ActionService.java
@@ -167,13 +167,11 @@ public class ActionService {
     if (Objects.equals(operation, Operation.LOAD)
         && !(dto.startDate().isBefore(ACTIONS_EPOCH))) {
 
-      if (dto.isFoundationProgramme()) {
-        deleteUnneededFoundationActions(dto, existingActions);
-      }
-
       Set<ActionType> actionTypes =
           dto.isFoundationProgramme() ? ActionType.getFoundationProgrammeActionTypes()
               : ActionType.getProgrammeActionTypes();
+
+      deleteUnneededActions(dto, existingActions, actionTypes);
 
       for (ActionType actionType : actionTypes) {
         Action newAction = mapper.toAction(dto, actionType);
@@ -268,22 +266,22 @@ public class ActionService {
   }
 
   /**
-   * Delete incomplete programme membership actions that are not valid for foundation programmes.
+   * Delete incomplete programme membership actions that are not valid.
    *
    * @param dto The programme membership being processed.
    * @param existingActions The existing actions for the programme membership.
+   * @param validActionTypes The valid action types for the programme membership.
    */
-  private void deleteUnneededFoundationActions(
-      ProgrammeMembershipDto dto, List<Action> existingActions) {
-    Set<ActionType> foundationActionTypes = ActionType.getFoundationProgrammeActionTypes();
+  private void deleteUnneededActions(
+      ProgrammeMembershipDto dto, List<Action> existingActions, Set<ActionType> validActionTypes) {
     // To avoid expensive database calls to delete non-existent actions, we filter the existing
-    // actions to find any incomplete actions that are not valid for foundation programmes,
+    // actions to find any incomplete actions that are not valid,
     // and only then delete those actions from the database using their type.
     List<ActionType> unneededActionTypes =
         existingActions.stream()
             .filter(action -> action.completed() == null)
             .map(Action::type)
-            .filter(actionType -> !foundationActionTypes.contains(actionType))
+            .filter(actionType -> !validActionTypes.contains(actionType))
             .distinct()
             .toList();
     unneededActionTypes.forEach(
@@ -295,7 +293,7 @@ public class ActionService {
                   PROGRAMME_MEMBERSHIP.toString(),
                   actionType.toString());
           log.info(
-              "{} unneeded foundation action(s) of type {} deleted for {} {}",
+              "{} unneeded action(s) of type {} deleted for {} {}",
               deletedActions.size(),
               actionType,
               PROGRAMME_MEMBERSHIP,

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -42,6 +42,7 @@ import static uk.nhs.tis.trainee.actions.model.ActionType.REGISTER_TSS;
 import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
 import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_COJ;
 import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_FORM_R_PART_A;
+import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_FORM_R_PART_B;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PERSON;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
@@ -57,6 +58,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -189,11 +191,10 @@ class ActionServiceTest {
     verifyNoInteractions(eventPublishingService);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"Foundation", "Not Foundation"})
-  void shouldNotInsertActionsOnAlreadyActionedPostEpochProgrammeMembership(String specialty) {
+  @Test
+  void shouldNotInsertActionsOnAlreadyActionedPostEpochProgrammeMembership() {
     ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
-        List.of(new CurriculumDto(specialty, null)));
+        List.of(new CurriculumDto("Not Foundation", null)));
 
     TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
     List<Action> existingActions = new ArrayList<>();
@@ -210,6 +211,75 @@ class ActionServiceTest {
     assertThat("Unexpected action count.", actions.size(), is(0));
     verify(repository).findByTraineeIdAndTisReferenceInfo(any(), any(), any());
     verifyNoMoreInteractions(repository);
+    verifyNoMoreInteractions(eventPublishingService);
+  }
+
+  @Test
+  void shouldNotInsertActionsOnAlreadyActionedPostEpochFoundationProgrammeMembership() {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto("Foundation", null)));
+
+    TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    List<Action> existingActions = new ArrayList<>();
+    for (ActionType actionType : ActionType.getFoundationProgrammeActionTypes()) {
+      Action existingAction = new Action(ObjectId.get(), actionType, TRAINEE_ID, tisReference,
+          PRE_EPOCH, POST_EPOCH, null);
+      existingActions.add(existingAction);
+    }
+    when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
+        .thenReturn(existingActions);
+    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        any(), any(), any(), any())).thenReturn(List.of());
+
+    List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
+
+    assertThat("Unexpected action count.", actions.size(), is(0));
+    Set<ActionType> nonFoundationTypes = ActionType.getProgrammeActionTypes().stream()
+        .filter(t -> !ActionType.getFoundationProgrammeActionTypes().contains(t))
+        .collect(Collectors.toSet());
+    for (ActionType actionType : nonFoundationTypes) {
+      verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+          TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), actionType.toString());
+    }
+    verifyNoMoreInteractions(eventPublishingService);
+  }
+
+  @Test
+  void shouldDeleteUnneededIncompleteActionsForFoundationProgramme() {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto("Foundation", null)));
+
+    TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action incompleteCoj = new Action(ObjectId.get(), SIGN_COJ, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, null);
+    Action incompleteFormA = new Action(ObjectId.get(), SIGN_FORM_R_PART_A, TRAINEE_ID,
+        tisReference, PRE_EPOCH, POST_EPOCH, null);
+    Action existingReviewData = new Action(ObjectId.get(), REVIEW_DATA, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, null);
+
+    when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
+        .thenReturn(List.of(existingReviewData));
+    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString()))
+        .thenReturn(List.of(incompleteCoj));
+    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_A.toString()))
+        .thenReturn(List.of(incompleteFormA));
+    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_B.toString()))
+        .thenReturn(List.of());
+
+    service.updateActions(Operation.LOAD, dto);
+
+    Set<ActionType> nonFoundationTypes = ActionType.getProgrammeActionTypes().stream()
+        .filter(t -> !ActionType.getFoundationProgrammeActionTypes().contains(t))
+        .collect(Collectors.toSet());
+    for (ActionType actionType : nonFoundationTypes) {
+      verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+          TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), actionType.toString());
+    }
+    verify(eventPublishingService).publishActionDeleteEvent(incompleteCoj);
+    verify(eventPublishingService).publishActionDeleteEvent(incompleteFormA);
     verifyNoMoreInteractions(eventPublishingService);
   }
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -228,19 +228,14 @@ class ActionServiceTest {
     }
     when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
         .thenReturn(existingActions);
-    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-        any(), any(), any(), any())).thenReturn(List.of());
 
     List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
 
     assertThat("Unexpected action count.", actions.size(), is(0));
-    Set<ActionType> nonFoundationTypes = ActionType.getProgrammeActionTypes().stream()
-        .filter(t -> !ActionType.getFoundationProgrammeActionTypes().contains(t))
-        .collect(Collectors.toSet());
-    for (ActionType actionType : nonFoundationTypes) {
-      verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-          TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), actionType.toString());
-    }
+    verify(repository).findByTraineeIdAndTisReferenceInfo(any(), any(), any());
+    verify(repository, never()).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        any(), any(), any(), any());
+    verifyNoMoreInteractions(repository);
     verifyNoMoreInteractions(eventPublishingService);
   }
 
@@ -258,26 +253,22 @@ class ActionServiceTest {
         PRE_EPOCH, POST_EPOCH, null);
 
     when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
-        .thenReturn(List.of(existingReviewData));
+        .thenReturn(List.of(incompleteCoj, incompleteFormA, existingReviewData));
     when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
         TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString()))
         .thenReturn(List.of(incompleteCoj));
     when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
         TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_A.toString()))
         .thenReturn(List.of(incompleteFormA));
-    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_B.toString()))
-        .thenReturn(List.of());
 
     service.updateActions(Operation.LOAD, dto);
 
-    Set<ActionType> nonFoundationTypes = ActionType.getProgrammeActionTypes().stream()
-        .filter(t -> !ActionType.getFoundationProgrammeActionTypes().contains(t))
-        .collect(Collectors.toSet());
-    for (ActionType actionType : nonFoundationTypes) {
-      verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-          TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), actionType.toString());
-    }
+    verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString());
+    verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_A.toString());
+    verify(repository, never()).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_B.toString());
     verify(eventPublishingService).publishActionDeleteEvent(incompleteCoj);
     verify(eventPublishingService).publishActionDeleteEvent(incompleteFormA);
     verifyNoMoreInteractions(eventPublishingService);

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -208,6 +208,8 @@ class ActionServiceTest {
 
     assertThat("Unexpected action count.", actions.size(), is(0));
     verify(repository).findByTraineeIdAndTisReferenceInfo(any(), any(), any());
+    verify(repository, never()).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        any(), any(), any(), any());
     verifyNoMoreInteractions(repository);
     verifyNoMoreInteractions(eventPublishingService);
   }

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -372,6 +372,31 @@ class ActionServiceTest {
   }
 
   @Test
+  void shouldNotCompleteCojActionOnFoundationProgrammeMembershipWithCoj() {
+    ConditionsOfJoining coj = new ConditionsOfJoining(Instant.MIN, "version", Instant.MAX);
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, coj,
+        List.of(new CurriculumDto("Foundation", null)));
+
+    TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action existingCoj = new Action(ObjectId.get(), SIGN_COJ, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, null);
+    Action existingReviewData = new Action(ObjectId.get(), REVIEW_DATA, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, null);
+
+    when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
+        .thenReturn(List.of(existingCoj, existingReviewData));
+    when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString()))
+        .thenReturn(List.of(existingCoj));
+
+    service.updateActions(Operation.LOAD, dto);
+
+    verify(repository, never()).save(any());
+    verify(eventPublishingService).publishActionDeleteEvent(existingCoj);
+    verifyNoMoreInteractions(eventPublishingService);
+  }
+
+  @Test
   void shouldNotUpdateActionWhenNoCojDataProvided() {
     CojReceivedEvent event = new CojReceivedEvent(TIS_ID, TRAINEE_ID, null);
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -216,9 +216,6 @@ class ActionServiceTest {
 
   @Test
   void shouldNotInsertActionsOnAlreadyActionedPostEpochFoundationProgrammeMembership() {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
-        List.of(new CurriculumDto("Foundation", null)));
-
     TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
     List<Action> existingActions = new ArrayList<>();
     for (ActionType actionType : ActionType.getFoundationProgrammeActionTypes()) {
@@ -228,6 +225,9 @@ class ActionServiceTest {
     }
     when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
         .thenReturn(existingActions);
+
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto("Foundation", null)));
 
     List<ActionDto> actions = service.updateActions(Operation.LOAD, dto);
 
@@ -241,9 +241,6 @@ class ActionServiceTest {
 
   @Test
   void shouldDeleteUnneededIncompleteActionsForFoundationProgramme() {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
-        List.of(new CurriculumDto("Foundation", null)));
-
     TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
     Action incompleteCoj = new Action(ObjectId.get(), SIGN_COJ, TRAINEE_ID, tisReference,
         PRE_EPOCH, POST_EPOCH, null);
@@ -260,6 +257,9 @@ class ActionServiceTest {
     when(repository.deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
         TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_A.toString()))
         .thenReturn(List.of(incompleteFormA));
+
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto("Foundation", null)));
 
     service.updateActions(Operation.LOAD, dto);
 

--- a/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/service/ActionServiceTest.java
@@ -42,7 +42,6 @@ import static uk.nhs.tis.trainee.actions.model.ActionType.REGISTER_TSS;
 import static uk.nhs.tis.trainee.actions.model.ActionType.REVIEW_DATA;
 import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_COJ;
 import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_FORM_R_PART_A;
-import static uk.nhs.tis.trainee.actions.model.ActionType.SIGN_FORM_R_PART_B;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PERSON;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.actions.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
@@ -58,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -267,11 +265,49 @@ class ActionServiceTest {
         TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_COJ.toString());
     verify(repository).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
         TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_A.toString());
-    verify(repository, never()).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
-        TRAINEE_ID, TIS_ID, PROGRAMME_MEMBERSHIP.toString(), SIGN_FORM_R_PART_B.toString());
     verify(eventPublishingService).publishActionDeleteEvent(incompleteCoj);
     verify(eventPublishingService).publishActionDeleteEvent(incompleteFormA);
     verifyNoMoreInteractions(eventPublishingService);
+  }
+
+  @Test
+  void shouldNotDeleteCompletedUnneededActionsForFoundationProgramme() {
+    TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action completedCoj = new Action(ObjectId.get(), SIGN_COJ, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, Instant.now());
+    Action existingReviewData = new Action(ObjectId.get(), REVIEW_DATA, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, null);
+
+    when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
+        .thenReturn(List.of(completedCoj, existingReviewData));
+
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto("Foundation", null)));
+
+    service.updateActions(Operation.LOAD, dto);
+
+    verify(repository, never()).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        any(), any(), any(), any());
+    verifyNoInteractions(eventPublishingService);
+  }
+
+  @Test
+  void shouldNotDeleteNonExistentUnneededActionsForFoundationProgramme() {
+    TisReferenceInfo tisReference = new TisReferenceInfo(TIS_ID, PROGRAMME_MEMBERSHIP);
+    Action existingReviewData = new Action(ObjectId.get(), REVIEW_DATA, TRAINEE_ID, tisReference,
+        PRE_EPOCH, POST_EPOCH, null);
+
+    when(repository.findByTraineeIdAndTisReferenceInfo(any(), any(), any()))
+        .thenReturn(List.of(existingReviewData));
+
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(TIS_ID, TRAINEE_ID, POST_EPOCH, null,
+        List.of(new CurriculumDto("Foundation", null)));
+
+    service.updateActions(Operation.LOAD, dto);
+
+    verify(repository, never()).deleteByTraineeIdAndTisReferenceInfoAndActionTypeAndNotComplete(
+        any(), any(), any(), any());
+    verifyNoInteractions(eventPublishingService);
   }
 
   @Test


### PR DESCRIPTION
Logic to prune unneeded foundation actions. To be triggered by redriving the programme membership table.

TIS21-8531