### PR TITLE
fix: ignore unknown curriculum attributes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.15.7"
+version = "0.15.8"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/tis/trainee/actions/event/ProgrammeMembershipListenerIntegrationTest.java
@@ -186,7 +186,7 @@ class ProgrammeMembershipListenerIntegrationTest {
               "tisId": "%s",
               "personId": "%s",
               "startDate": "%s",
-              "curricula": "[{\\"curriculumSubType\\":\\"AFT\\",\\"curriculumSpecialty\\":\\"Foundation\\"}]"
+              "curricula": "[{\\"curriculumTisId\\":\\"123\\",\\"curriculumSubType\\":\\"AFT\\",\\"curriculumSpecialty\\":\\"Foundation\\"}]"
             },
             "operation": "%s"
           }

--- a/src/main/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializer.java
+++ b/src/main/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializer.java
@@ -25,9 +25,9 @@ package uk.nhs.tis.trainee.actions.dto.helpers;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.util.List;
@@ -42,7 +42,7 @@ public class CurriculaDeserializer extends JsonDeserializer<List<CurriculumDto>>
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
       .registerModule(new JavaTimeModule())
-      .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   /**
    * Deserialize a JSON string into a CurriculumDto List. Note that a serialized value of "null"
@@ -57,6 +57,7 @@ public class CurriculaDeserializer extends JsonDeserializer<List<CurriculumDto>>
   public List<CurriculumDto> deserialize(JsonParser p, DeserializationContext ctxt)
       throws IOException {
     String curriculaString = p.getValueAsString();
-    return OBJECT_MAPPER.readValue(curriculaString, new TypeReference<>() {});
+    return OBJECT_MAPPER.readValue(curriculaString, new TypeReference<>() {
+    });
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/actions/dto/helpers/CurriculaDeserializerTest.java
@@ -61,10 +61,12 @@ class CurriculaDeserializerTest {
     String validJson = """
         [
           {
+            "curriculumTisId": "123",
             "curriculumSubType": "subType1",
             "curriculumSpecialty": "specialty1"
           },
           {
+            "curriculumTisId": "321",
             "curriculumSubType": "subType2",
             "curriculumSpecialty": "specialty2"
           }


### PR DESCRIPTION
Reconfigure the Jackson mapper to ignore unknown attributes, the curriculum has many more attributes than are needed. So to avoid mapping unused data the `FAIL_ON_UNKNOWN_PROPERTIES` feature should be disabled.

TIS21-8528
TIS21-8529